### PR TITLE
Reorganise the development checklist steps

### DIFF
--- a/onboarding.md
+++ b/onboarding.md
@@ -104,47 +104,49 @@ TODO
 
 
 Developers Onboarding [REMOVE IF NOT APPLICABLE]
-------------------
+---------------------
 
-### Light reading and listening
+#### Light reading and listening
 * [ ] Give podcasts a try - listen to 5 episodes to see if they work for you: we recommend starting with Podcast.__init__, FLOSS Weekly and/or The Tim Ferris Show.
 * [ ] Subscribe to http://planetpython.org/ RSS. If you do not have an RSS reader, you can [use IFTTT to send RSS feed into your inbox](https://ifttt.com/applets/147561p-rss-feed-to-email).
 
-### Python
+#### Python
 * [ ] Glance over [Fluent Python](http://books.niteoweb.com.s3.amazonaws.com/tech/Python/Fluent_Python.pdf).
-* [ ] Read [Expert Python Programing](http://books.niteoweb.com.s3.amazonaws.com/tech/Python/Expert%20Python%20Programming/Expert%20Python%20Programming%20(info@niteoweb.com).pdf) (pass: info@niteoweb.com) chapters 10 (Documentation) and 11 (Test-Driven Development).
+* [ ] Read over Chapters 10 (Docs) and 11 (TDD) in [Expert Python Programing](http://books.niteoweb.com.s3.amazonaws.com/tech/Python/Expert%20Python%20Programming/Expert%20Python%20Programming%20(info@niteoweb.com).pdf) (pass: info@niteoweb.com).
 * [ ] Glance over [Python typing](https://docs.python.org/3/library/typing.html).
-* [ ] Read [makefiles in python projects](https://krzysztofzuraw.com/blog/2016/makefiles-in-python-projects.html).
+* [ ] Read about [makefiles in python projects](https://krzysztofzuraw.com/blog/2016/makefiles-in-python-projects.html).
 * [ ] Read about [mocking](https://www.toptal.com/python/an-introduction-to-mocking-in-python).
+* [ ] Watch [PDB Like a Pro by Philip Bauer](https://www.youtube.com/watch?v=NKSW6pDX3Dc).
 
-### Pyramid - Web framework
-* [ ] Read https://trypyramid.com/.
-* [ ] Read http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tour.html.
-* [ ] Follow http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/index.html.
-* [ ] Read about [Chameleon](https://chameleon.readthedocs.io/en/latest/) template engine.
-* [ ] Read about [Pylons (Legacy web framework)](http://pylonsproject.org/about-pylons-project.html).
+#### Pyramid - Web framework
+* [ ] Read about [Pyramid](https://trypyramid.com/).
+* [ ] Read the [Quick Tour](http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tour.html).
+* [ ] Follow the [Quick Tutorial](http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/index.html).
+* [ ] Read about [Chameleon](https://chameleon.readthedocs.io/en/latest/) HTML/XML template engine.
 
-### Sqlalchemy - SQL toolkit
+#### Sqlalchemy - SQL toolkit
 * [ ] Follow the [introduction tutorial](http://pythoncentral.io/introductory-tutorial-python-sqlalchemy/).
 * [ ] Read over [ORM examples](http://pythoncentral.io/sqlalchemy-orm-examples/).
 * [ ] Read about [Association tables](http://pythoncentral.io/sqlalchemy-association-tables/).
 
-### Test, build and deployment
+#### Test, build and deployment
 * [ ] Read about [Travis Continous Integration](https://docs.travis-ci.com/user/for-beginners) service.
 * [ ] Watch [Learn How We Deliver. Continuously., by Nejc Zupan](https://www.youtube.com/watch?v=4GZcW19c4GM)
 * [ ] Glance over [Buildout](http://docs.buildout.org/en/latest/).
 * [ ] Glance over [Heroko](https://devcenter.heroku.com/categories/heroku-architecture) deployment.
 
-### Development Process
-* [ ] Join the #development channel on Slack.
+#### Development Methodology
 * [ ] We build our apps based on the [Twelve-Factor](https://12factor.net) methodology. Make sure you understand it.
-* [ ] Read about [git workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#feature-branch-workflow).
-* [ ] Read about our [Development Process](http://docs.niteoweb.com/pyramid_bimt/process.html).
 * [ ] Watch [UncleBob Expecting Professionalism](https://www.youtube.com/watch?v=BSaAMQVq01E).
-* [ ] Study [python-requests](http://python-requests.org) for an example of beautiful code, good API design and docs that are a pleasure to read.
-* [ ] Watch [PDB Like a Pro by Philip Bauer](https://www.youtube.com/watch?v=NKSW6pDX3Dc).
+* [ ] Read about the [Pylons Project](http://pylonsproject.org/about-pylons-project.html).
+* [ ] Study [python-requests](http://python-requests.org) for an example of beautiful code, good API design and readable docs.
+* [ ] Read about [git workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#feature-branch-workflow).
+
+#### Development Process
+* [ ] Join the #development channel on Slack.
 * [ ] Glance over [devs-macbook-from-scratch](https://blog.niteoweb.com/a-devs-macbook-from-scratch/) (mostly aimed at Mac users).
-* [ ] Make sure all [Prerequisites](http://docs.niteoweb.com/pyramid_bimt/develop.html#prerequisites) are taken care of.
+* [ ] Read about our [Development Process](http://docs.niteoweb.com/pyramid_bimt/process.html).
+* [ ] Ensure all [Prerequisites](http://docs.niteoweb.com/pyramid_bimt/develop.html#prerequisites) are taken care of.
 * [ ] Ask @niteoweb/peopleops to give you access to the [pyramid_bimt](https://github.com/niteoweb/pyramid_bimt) repository by posting a comment on this issue.
 
 
@@ -152,7 +154,10 @@ On your first day
 =================
 
 * [ ] Join the Daily Standup meeting.
-* [ ] [Choose your first task](https://intra.niteoweb.com/operations/how-to-find-work)! We strive to enable everyone to do something valuable the very first day. For developers, this means pushing something into production, for support staff answering a few support questions and for marketing publishing the first ad.
+* [ ] [Choose your first task](https://intra.niteoweb.com/operations/how-to-find-work)! We strive to enable everyone to do something valuable the very first day, for example:
+  - Developers will be pushing something into production.
+  - Support staff will be answering a few support questions.
+  - Marketing will be publishing their first advert.
 ```
 
 # [Email Template] First Email


### PR DESCRIPTION
* Add a dev methodology heading for general reading.
* Add Pyramid link descriptions
* Use h4 for 'lighter' development headings
* Put 'first day' tasks into a more readable list