### PR TITLE
Updated policy on EOS frequency

### DIFF
--- a/everyone-on-support.md
+++ b/everyone-on-support.md
@@ -25,7 +25,7 @@ In the end, we are working for our customers, and having everyone involved in th
 
 ### II. Frequency
 
-EOS is once every month. 
+Report for EOS once every month. You don't have to complete all 7.5 hours. The idea is to close all open tickets (you can leave billing and other complex tickets to support staff). Once done, you can resume doing your regular tasks.
 
 Since we're on Sprints, it's expected that Team Capacity will be affected and duly adjusted.
 


### PR DESCRIPTION
It's already the case but we want this in policy. So instead of idling by waiting for a support ticket to come, you can resume to doing your regular tasks once you've "cleaned" GrooveHQ. "Cleaned" can either be zero emails in Groove or no more open tickets that are assigned to you.

This affects everyone doing EOS so I'm assigning everyone as reviewers.