### PR TITLE
Reorganise onboarding page by splitting out templates

### DIFF
--- a/managing-docs.md
+++ b/managing-docs.md
@@ -38,3 +38,13 @@ Guidelines on which information goes where.
 
 - Finance reports and meeting minutes should be posted on Intra.
 - Company work processes and general documentation should be posted to Handbook.
+
+### Handbook
+
+- Checklists for operational issues should be stored in
+`.github/ISSUE_TEMPLATES` and then linked to in the handbook, for example:
+
+    `https://github.com/niteoweb/operations/issues/new?template=onboarding-trialist.md&title=Onboarding:%20FirstName%20LastName&label=people`
+
+- Any templates for emails, contracts, etc. should be stored in the handbook
+`templates` directory.

--- a/onboarding.md
+++ b/onboarding.md
@@ -13,8 +13,7 @@ We don't believe in long interview processes with tricky questions and unrealist
 
 The trial period lasts somewhere between 3 to 6 months. Normally, the trialist receives roughly 70% of the salary others earn in a similar position (there can be exceptions).
 
-The trialist is not included in [profit sharing](https://github.com/niteoweb/handbook/blob/master/profit-sharing.md) and other [benefits](https://github.com/niteoweb/handbook/blob/master/benefits.md) and does not get a [severance](#lay-off--severance-policy) package.
-
+As a trialist you will not be included in [profit sharing](profit-sharing.md) and other [benefits](benefits.md), nor entitled to a [severance](salary.md#severance) package.
 
 ## Getting Started
 
@@ -29,295 +28,88 @@ That is it! Go to your onboarding issue and start checking things off!
 
 ## PeopleOps checklist
 
-A member of the @niteoweb/peopleops team will do the following to start the onboarding process:
+A member of the [PeopleOps] team will do the following to start the onboarding process:
 
-* Add the new team member to the [@niteoweb/trialists](https://github.com/orgs/niteoweb/teams/trialists) group so they get access to [niteoweb/operations](https://github.com/niteoweb/operations) and [niteoweb/handbook](https://github.com/niteoweb/handbook) repositories.
-* Create an onboarding issue based on the template below and assign it to the new team member.
-* Send the first email (see First Email email template below).
-* Create @niteo.co email address and send over credentials (see Niteo Email Account email template below).
-
-
-## Lay Off / Severance Policy
-
-While many of us are good friends, we are still a business, not a family. Unlike a family, people join and leave us from time to time. Whenever we have to let someone go, this is how we do it.
-
-* The person needs to know at least 1 month in advance that their position could be canceled in the near term.
-* The person needs to know that if we will be hiring for the same position again in the future, they will have priority over completely new people.
-* All Partners need to agree with cancellation.
-* When cancellation is agreed, the person should be notified immediately. From this point onwards, the person is no longer required to work, but is encouraged to take their time to hand off to other people in the Niteo anything they feel is valuable. After hand-off is finished they are free to do whatever.
-* Every Nitean (except Trialists) is entitled to a severance package according to the following formula:
-  * up to one year: 1 month base salary,
-  * more than one year: 2 months base salary + 1 month for each additional year, up to max 12 months total.
-
-
-# Onboarding Issue Template
-
-## Trial
-
-```
-Hello and welcome to Niteo! If you have not done so yet, please read https://github.com/niteoweb/handbook/blob/master/onboarding.md to get an idea of what this is.
-
-
-Gearing up
-==========
-
-### Email Setup
-* [ ] A member of the @niteoweb/peopleops team will create your very own `<initials>@niteo.co` email address. Use it for all Niteo-related communication, internally and with third-party contacts. Please ask if you would prefer a different address.
-* [ ] We use S/MIME encryption for all email communication so install a desktop-based email client that supports S/MIME encryption e.g.  Apple Mail or Mozilla Thunderbird. *(Please do not use Web-based clients)*.
-* [ ] Generate a [free Comodo Certificate](https://www.comodo.com/home/email-security/free-email-certificate.php) *(Chrome users: There were past problems with Comodo's form, try using Firefox if nothing happens)*.
-* [ ] Configure S/MIME encryption for your email client. You will need to Google configuration details for your particular email client and verify that encryption works by emailing someone from the @niteoweb/peopleops team.
-* [ ] Set up your [email signature](https://github.com/niteoweb/handbook/blob/master/onboarding.md). Google how to do it for your email client of choice. Choose whatever title you want.
-* [ ] Upload your photo for your @niteo.co email on [Gravatar](https://en.gravatar.com/). Please use a photo where your face is visible. We are a remote team and having a cat for the avatar does not help in building a relationship with others.
-* [ ] Add your @niteo.co email to your [GitHub account](https://help.github.com/articles/adding-an-email-address-to-your-github-account/).
-
-### Team Communication
-* [ ] Signup to [Zoom](https://zoom.us/signup), our video conferencing software.
-* [ ] Signup to [Slack](https://join.slack.com/niteoweb/signup). This is our Team Chat and please use your GitHub username as your display name.
-* [ ] Read [Using Slack](https://github.com/niteoweb/handbook/blob/master/using-slack.md). Take some time to read through old messages in main channels to get an idea of how we function.
-* [ ] Signup to [Grammarly](https://www.grammarly.com/). This ensures all our correspondence has the correct US English spelling and grammar.
-* [ ] Introduce yourself by saying 'Hi' and writing a sentence about yourself in the #operations Slack channel.
-
-### VPN and Intra
-* [ ] With email setup, now configure the OpenVPN secure tunnel so you can connect to our internal services. Mac users should install `Tunnelblick` app and Linux users the `openvpn` package. Then ask @zupo (post comment to this issue) to email you the OpenVPN configuration files, which you normally double-click on and follow the instructions.
-* [ ] Once connected to our VPN you will be able to access https://intra.niteoweb.com/. Ask @niteoweb/peopleops (post comment to this issue) to create an account for you along with your [Team Member Page](https://intra.niteoweb.com/people/team-members) on Intra. Your login credentials will arrive in a separate email.
-
-
-Time for some reading up!
--------------------------------
-
-* [ ] Thoroughly read through our [Handbook](https://github.com/niteoweb/handbook).
-* [ ] Watch the initial [State of Niteo](http://videos.niteoweb.com.s3.amazonaws.com/IRL%231%2F%5BIRL%231%5D%20State%20of%20NW.mp4) talk from our first In-Real-Life meet  ([talk slides](http://videos.niteoweb.com.s3.amazonaws.com/IRL%231%2F%5BIRL%231%5D%20State%20of%20NW%20-%20SLIDES.pdf)).
-* [ ] Watch the most recent [IRL meet](http://videos.niteoweb.com.s3.amazonaws.com/IRL%233%2F%5BIRL%233%5D%20State%20of%20Niteo.mp4).
-* [ ] Read a few of our latest [Newsletters](https://intra.niteoweb.com/operations/company-newsletter) to catch up on recent events.
-
-Learn about our currently active projects:
- * [ ] [Easy Blog Network](http://docs.niteoweb.com/ebn/)
- * [ ] [Easy Domain Monitor](http://docs.niteoweb.com/dmon/)
-
-
-Marketing Onboarding [REMOVE IF NOT APPLICABLE]
---------------------
-
-TODO
-
-
-Support Onboarding [REMOVE IF NOT APPLICABLE]
-------------------
-### Getting Started
-* [ ] Go to Groove Settings, click on Profile and update what's necessary (name, title and add image).
-* [ ] Learn how [support requeste are handled.](https://github.com/niteoweb/handbook/blob/master/support.md)
-* [ ] See our policy on [dealing with users.](https://github.com/niteoweb/ebn-support/blob/master/dealing-with-users.md)
-
-#### Easy Blog Networks
-* [ ] You need to learn about the product. Read everything including those in the footer links on the [EBN sales page.](https://www.easyblognetworks.com/)
-* [ ] Read through everything in the [ebn-support repository.](https://github.com/niteoweb/ebn-support)
-* [ ] Go through all our [Help Articles.](https://help.easyblognetworks.com/)
-* [ ] Read our [blog.](https://blog.easyblognetworks.com/)
-
-Developers Onboarding [REMOVE IF NOT APPLICABLE]
----------------------
-#### Light Listening
-* [ ] Try out podcasts, listen to 5 episodes and see if they work for you. We recommend starting with [Podcast.\_\_init\_\_](https://www.podcastinit.com/), [FLOSS Weekly](https://twit.tv/shows/floss-weekly) and/or [The Tim Ferris Show](https://tim.blog/podcast/).
-
-#### Development Methodology
-* [ ] Read and understand how we build our apps based on the [Twelve-Factor](https://12factor.net) methodology.
-* [ ] Watch [UncleBob Expecting Professionalism](https://www.youtube.com/watch?v=BSaAMQVq01E).
-* [ ] Watch coding example of [Three laws of TDD](https://youtu.be/qkblc5WRn-U?t=27m7s) (from 27:00 to 43:00 marks).
-* [ ] Read about the [Pylons Project](http://pylonsproject.org/about-pylons-project.html).
-* [ ] Study [python-requests](http://python-requests.org) for an example of beautiful code, good API design and readable docs.
-* [ ] Read about [git workflow](https://www.atlassian.com/git/tutorials/comparing-workflows#feature-branch-workflow).
-
-#### Python
-* [ ] Glance over [Fluent Python](http://books.niteoweb.com.s3.amazonaws.com/tech/Python/Fluent_Python.pdf).
-* [ ] Read about writing Documentation in chapter 10 of [Expert Python Programing](http://books.niteoweb.com.s3.amazonaws.com/tech/Python/Expert%20Python%20Programming/Expert%20Python%20Programming%20(info@niteoweb.com).pdf) *(pass: `info@niteoweb.com`)*.
-* [ ] Glance over [Type Hinting](https://docs.python.org/3/library/typing.html) and [Enums](https://docs.python.org/3/library/enum.html).
-* [ ] Read about [mocking](https://www.toptal.com/python/an-introduction-to-mocking-in-python) in Unit Tests.
-* [ ] Watch [PDB Like a Pro by Philip Bauer](https://www.youtube.com/watch?v=NKSW6pDX3Dc).
-* [ ] Read about [Test Driven Development (TDD)](https://code.tutsplus.com/tutorials/beginning-test-driven-development-in-python--net-30137) in Python.
-* [ ] Subscribe to [Planet Python](http://planetpython.org/) RSS feed. If you do not have an RSS reader, you can send it to your inbox with [IFTTT](https://ifttt.com/applets/147561p-rss-feed-to-email).
-
-#### Sqlalchemy - SQL Toolkit
-* [ ] Install with `pip install SQLAlchemy`.
-* [ ] Follow the [introduction tutorial](http://pythoncentral.io/introductory-tutorial-python-sqlalchemy/).
-* [ ] Read over [ORM examples](http://pythoncentral.io/sqlalchemy-orm-examples/).
-* [ ] Read about [Association tables](http://pythoncentral.io/sqlalchemy-association-tables/).
-
-#### Pyramid - Web Framework
-* [ ] Read about [Pyramid](https://trypyramid.com/).
-* [ ] Read about [Chameleon](https://chameleon.readthedocs.io/en/latest/) HTML/XML template engine.
-* [ ] Follow the [Quick Tutorial](http://docs.pylonsproject.org/projects/pyramid/en/latest/quick_tutorial/index.html).
-
-#### Test, Build, Deploy
-* [ ] Read about [Travis CI](https://docs.travis-ci.com/user/for-beginners).
-* [ ] Watch [Learn How We Deliver. Continuously. by Nejc Zupan](https://www.youtube.com/watch?v=4GZcW19c4GM)
-* [ ] Glance over [Buildout](http://docs.buildout.org/en/latest/).
-* [ ] Glance over [Heroko](https://devcenter.heroku.com/categories/heroku-architecture) deployment.
-* [ ] Read about [makefiles in python projects](https://krzysztofzuraw.com/blog/2016/makefiles-in-python-projects.html).
-
-#### Niteo Development Process
-* [ ] Join the `#development` channel on Slack.
-* [ ] Glance over [devs-macbook-from-scratch](https://blog.niteoweb.com/a-devs-macbook-from-scratch/) (mostly aimed at Mac users).
-* [ ] Read about our [Development Process](http://docs.niteoweb.com/pyramid_bimt/process.html).
-* [ ] Ensure all [Prerequisites](http://docs.niteoweb.com/pyramid_bimt/develop.html#prerequisites) are taken care of.
-* [ ] Ask @niteoweb/peopleops to give you access to the [pyramid_bimt](https://github.com/niteoweb/pyramid_bimt) repository and `PYPICLOUD` credentials to access the [Internal PyPI server](https://intra.niteoweb.com/development/internal-pypi-server) by posting a comment on this issue.
-
-
-On your first day
-=================
-
-* [ ] Join the Daily Standup meeting.
-* [ ] Confirm the Intellectual Property Rights disclaimer with a comment in your onboarding issue.
-* [ ] [Choose your first task](https://github.com/niteoweb/handbook/blob/master/next-task.md)! We strive to enable everyone to do something valuable the very first day, for example:
-  - Developers will be pushing something into production.
-  - Support staff will be answering a few support questions.
-  - Marketing will be publishing their first advert.
-```
-
-## Intellectual Property Rights
-
-Add a comment in your onboarding issue with this section, add your name in the two fields, read it and add “I agree” to the bottom.
-
-
-```
-
-**Client:** Niteo.co SI Ltd.
-**Contractor:** [FirstName LastName]
-
-# Intellectual Property Rights
-
-## Product
-
-All materials, including, but not limited to, software, programs, source code and object code, comments to the source or object code, specifications, documents, abstracts and summaries thereof (collectively, the “Products”) developed by Contractor in connection with the provision of the Services to Client, or jointly by Client and Contractor, or by Contractor pursuant to specifications or instructions provided by Client, shall belong exclusively to Client. Contractor acknowledges that the Products shall be deemed “works made for hire” by Contractor for Client, and, therefore, shall be the exclusive property of Client. To the extent the Products are not deemed “works made for hire” under applicable law, Contractor hereby irrevocably assigns and transfers to Client all right, title and interest in and to the Products, including, without limitation, all patent and copyright interests, and agrees to execute all documents reasonably requested by Client for the purpose of applying for and obtaining domestic and foreign patent and copyright registrations.
-
-
-## Pre-existing Intellectual Property
-
-Notwithstanding any provision of this Agreement to the contrary, any routines, methodologies, processes, libraries, tools or technologies created, adapted or used by Contractor in its business generally, including all associated intellectual property rights (collectively, the “Development Tools”), shall be and remain the sole property of Contractor, and Client shall have no interest in or claim to the Development Tools, except as necessary to exercise its rights in the Products. In addition, notwithstanding any provision of this Agreement to the contrary, Contractor shall be free to use any ideas, concepts, or know-how developed or acquired by Contractor during the performance of this Agreement to the extent obtained and retained by Contractor’s personnel as impression and general learning. Subject to and limited by Client’s intellectual property rights described in Section above, nothing in this Agreement shall be construed to preclude Contractor from using the Development Tools for use with third parties for the benefit of Contractor.
-
-—
-
-I agree - [FirstName LastName]
-
-```
-
-## Full Time
-
-```
-* [ ] Access to team 1Password.
-* [ ] Added to group Full Time on intra, gaining access to private reports.
-* [ ] Access to Heroku apps.
-* [ ] Join NiteoWeb Team on GitHub.
-* [ ] ZenHub Team invitation.
-* [ ] Invite to donations spreadsheet.
-* [ ] Configure Resilio Sync.
-```
-
-# [Email Template] First Email
-
-```
-Hey!
-
-Welcome to Niteo! We keep everything related to work on GitHub so I will be short:
-* read https://github.com/niteoweb/handbook/blob/master/onboarding.md,
-* open <LINK TO ONBOARDING ISSUE> and start at the top.
-
-
+* Add the new team member to the [Trialists] group, allowing access to [operations](https://github.com/niteoweb/operations) and [handbook](https://github.com/niteoweb/handbook) repositories.
+* Create a new [Trialist Onboarding Issue] and assign it to the new team member.
+* Send the <a href="mailto:?
+subject=Welcome to Niteo
+&body=
+Hey!%0D%0A
+%0D%0A
+Welcome to Niteo! We keep everything related to work on GitHub so I will be short:%0D%0A
+%0D%0A
+• First, please read https://github.com/niteoweb/handbook/blob/master/onboarding.md%0D%0A
+• Then go to LINK TO ONBOARDING ISSUE and start at the top.%0D%0A
+%0D%0A
+%0D%0A
+Regards%0D%0A
+%0D%0A
+" target="_blank">
+Welcome to Niteo
+</a>email.
+* Create a `@niteo.co` email address and send the <a href="mailto:?
+subject=Niteo Email Account
+&cc=@niteo.co
+&body=
+Hey!%0D%0A
+%0D%0A
+Here's your Niteo email. You'll be using it for communication with us and for subscribing to websites.%0D%0A
+%0D%0A
+w: https://apps.rackspace.com/%0D%0A
+u: [email]%0D%0A
+p: [pass]%0D%0A
+%0D%0A
+Please change your password immediately after you login. You can do that in the
+ top right Settings menu.%0D%0A
+%0D%0A
+Configure the email on your desktop app, find the instructions here:
+ https://emailhelp.rackspace.com%0D%0A
+%0D%0A
+The next thing that you need to do is set up S/MIME email encryption. Generate
+ a Comodo Certificate at
+https://www.comodo.com/home/email-security/free-email-certificate.php.%0D%0A
+%0D%0A
+This email is signed with my cert, you should be able to reply with a
+ message, signed with your cert so that I can then reply back with an encrypted
+ message as well.%0D%0A
+%0D%0A
+Once you have encryption ready, I will send over more information.%0D%0A
+%0D%0A
+%0D%0A
 Regards
-```
-
-
-
-# [Email Template] Niteo Email Account
-
-```
-Hey!
-
-Here's your Niteo email. You'll be using it for communication with us and for subscribing to websites.
-
-w: https://apps.rackspace.com/
-u: [email]
-p: [pass]
-
-Please change your password immediately after you login. You can do that in the top right Settings menu.
-
-Configure the email on your desktop app, find the instructions here: https://emailhelp.rackspace.com
-
-The next thing that you need to do is set up S/MIME email encryption. Generate a Comodo Certificate at https://www.comodo.com/home/email-security/free-email-certificate.php. You’ll need to Google on how to set encryption on your desktop app.
-
-This email is signed with my cert, you should be able to reply with an encrypted message, signed with your cert so that I can then reply back with an encrypted message as well.
-
-Once you have encryption ready, I’m sending over more information.
-
-
+" target="_blank">
+account credentials
+</a> email.
+* Once email encryption is setup, send the <a href="mailto:@niteo.co?
+subject=Niteo OpenVPN
+&body=
+Hey!%0D%0A
+%0D%0A
+Now that encryption is configured, you need to configure OpenVPN so you can
+ connect to our internal services.%0D%0A
+%0D%0A
+Configuration files are attached, normally you just double-click them and follow
+ instructions.%0D%0A
+%0D%0A
+When you manage to connect to our VPN you will then be able to access our
+ internal services, such as http://docs.niteoweb.com/.%0D%0A
+%0D%0A
+%0D%0A
 Regards
-```
+" target="_blank">
+OpenVPN configuration
+</a> email.
+* Upon promotion to a full-time position, create a [Full-time Onboarding Issue].
+* Upon leaving Niteo, create an [Offboarding Issue].
 
+<!-- References --->
 
-# [Email Template] OpenVPN Access
-
-```
-Hey!
-
-Now that encryption is configured, you need to configure OpenVPN so you can connect to our internal services.
-
-Configuration files are attached, normally you just double-click them and follow instructions.
-
-When you manage to connect to our VPN you will then be able to access our internal services, such as http://docs.niteoweb.com/.
-
-
-Regards
-```
-
-# Email Signatures
-
-A few examples to base your signature off of. Choose your own title, it can be whatever you wish.
-
-```
-Richard Hendricks
-
-CEO
----------------
-Niteo.co
-
-E: rh@niteo.co
-W: www.niteo.co
-```
-
-```
-Erlich Bachmann
-
-Backend Specialist
-------------------
-Niteo.co
-
-E: eb@niteo.co
-W: www.niteo.co
-```
-```
-Monica Hall
-
-Senior (con)Sultan
-------------------
-Niteo.co
-
-E: mh@niteo.co
-W: www.niteo.co
-```
-
-# Offboarding
-
-```
-* [ ] Access to team 1Password.
-* [ ] Heroku access.
-* [ ] GitHub repositories access.
-* [ ] PyPICloud access.
-* [ ] Donations spreadsheet.
-* [ ] Slack access.
-* [ ] Email account.
-* [ ] Intra account.
-* [ ] VPN access.
-* [ ] Zoom.us account.
-* [ ] Sentry access.
-* [ ] EBN account.
-* [ ] DMON account.
-```
+[PeopleOps]: https://github.com/orgs/niteoweb/teams/peopleops
+[Trialists]: https://github.com/orgs/niteoweb/teams/trialists
+[Trialist Onboarding Issue]:
+https://github.com/niteoweb/operations/issues/new?template=onboarding-trialist.md&title=Onboarding:%20[FirstName%20LastName]&label=people
+[Full-time Onboarding Issue]:
+https://github.com/niteoweb/operations/issues/new?template=onboarding-full-time.md&title=Full-time%20onboarding:%20[FirstName%20LastName]&label=people
+[Offboarding Issue]:
+https://github.com/niteoweb/operations/issues/new?template=offboarding.md&title=Offboarding:%20[FirstName%20LastName]&label=people

--- a/salary.md
+++ b/salary.md
@@ -58,3 +58,15 @@ Track all hours spent working for the company:
 * do not track non-meeting lunch
 
 Everyone tracks working hours for themselves. At the end of each month, send your **total working hours *and* sick leave days** to Dejan. We don't need breakdown per day or per task. You don't need to count vacation hours or sick leave, all that is done automatically and the balance posted to your [Intra profile](https://intra.niteoweb.com/resolveuid/8027d5b5-0b78-4a85-8d43-d419c82e98fd) at the beginning of each month.
+
+# Lay Off / Severance Policy
+
+While many of us are good friends, we are still a business, not a family. Unlike a family, people join and leave us from time to time. Whenever we have to let someone go, this is how we do it.
+
+* The person needs to know at least 1 month in advance that their position could be canceled in the near term.
+* The person needs to know that if we will be hiring for the same position again in the future, they will have priority over completely new people.
+* All Partners need to agree with cancellation.
+* When cancellation is agreed, the person should be notified immediately. From this point onwards, the person is no longer required to work, but is encouraged to take their time to hand off to other people in the Niteo anything they feel is valuable. After hand-off is finished they are free to do whatever.
+* Every Nitean (except Trialists) is entitled to a severance package according to the following formula:
+  * up to one year: 1 month base salary,
+  * more than one year: 2 months base salary + 1 month for each additional year, up to max 12 months total.

--- a/templates/email-signatures.md
+++ b/templates/email-signatures.md
@@ -1,0 +1,35 @@
+# Email Signatures
+
+A few examples to base your signature off of. Choose your own title, it can be whatever you wish.
+
+```
+Richard Hendricks
+
+CEO
+---------------
+Niteo.co
+
+E: rh@niteo.co
+W: www.niteo.co
+```
+
+```
+Erlich Bachmann
+
+Backend Specialist
+------------------
+Niteo.co
+
+E: eb@niteo.co
+W: www.niteo.co
+```
+```
+Monica Hall
+
+Senior (con)Sultan
+------------------
+Niteo.co
+
+E: mh@niteo.co
+W: www.niteo.co
+```

--- a/templates/email-signatures.md
+++ b/templates/email-signatures.md
@@ -23,13 +23,10 @@ Niteo.co
 E: eb@niteo.co
 W: www.niteo.co
 ```
+
+For the minimalist, we would suggest this slimmer signature:
+
 ```
-Monica Hall
-
-Senior (con)Sultan
-------------------
-Niteo.co
-
-E: mh@niteo.co
-W: www.niteo.co
+Monica Hall, Senior (con)Sultan
+niteo.co | +386 40 123 456 | skype: monica.hall | @mhall
 ```

--- a/templates/ip-contract.md
+++ b/templates/ip-contract.md
@@ -1,0 +1,24 @@
+
+## Intellectual Property Rights Disclaimer
+
+Read this contract over and put your name in the two places marked.
+
+```
+**Client:** Niteo.co SI Ltd.
+**Contractor:** [FirstName LastName]
+
+# Intellectual Property Rights
+
+## Product
+
+All materials, including, but not limited to, software, programs, source code and object code, comments to the source or object code, specifications, documents, abstracts and summaries thereof (collectively, the “Products”) developed by Contractor in connection with the provision of the Services to Client, or jointly by Client and Contractor, or by Contractor pursuant to specifications or instructions provided by Client, shall belong exclusively to Client. Contractor acknowledges that the Products shall be deemed “works made for hire” by Contractor for Client, and, therefore, shall be the exclusive property of Client. To the extent the Products are not deemed “works made for hire” under applicable law, Contractor hereby irrevocably assigns and transfers to Client all right, title and interest in and to the Products, including, without limitation, all patent and copyright interests, and agrees to execute all documents reasonably requested by Client for the purpose of applying for and obtaining domestic and foreign patent and copyright registrations.
+
+
+## Pre-existing Intellectual Property
+
+Notwithstanding any provision of this Agreement to the contrary, any routines, methodologies, processes, libraries, tools or technologies created, adapted or used by Contractor in its business generally, including all associated intellectual property rights (collectively, the “Development Tools”), shall be and remain the sole property of Contractor, and Client shall have no interest in or claim to the Development Tools, except as necessary to exercise its rights in the Products. In addition, notwithstanding any provision of this Agreement to the contrary, Contractor shall be free to use any ideas, concepts, or know-how developed or acquired by Contractor during the performance of this Agreement to the extent obtained and retained by Contractor’s personnel as impression and general learning. Subject to and limited by Client’s intellectual property rights described in Section above, nothing in this Agreement shall be construed to preclude Contractor from using the Development Tools for use with third parties for the benefit of Contractor.
+
+—
+
+I agree - [FirstName LastName]
+```


### PR DESCRIPTION
 * Using the new github issue multi-template option allows the checklists
to be moved to operations repo.
 * Moved email templates and IP contract to templates sub-dir.
 * Split severance details into salary page.
 * Update the peopleops section of onboarding with new links.
