### PR TITLE
Productivity Allowance budget is given in the same currency as your salary

### DIFF
--- a/people/benefits.md
+++ b/people/benefits.md
@@ -35,14 +35,26 @@ In other words, would something boost your productivity and creativity? Good, fe
 
 ### Monthly budget
 
-The current allowance budget as of *February 2018* is:
+The current allowance budget as of *January 2018* is:
 
- * Niteans: _€150_
- * Founders: _€300_
+ * Niteans: _€125_
+ * Founders: _€250_
 
 The monthly budgets compound every month, so whatever you do not spend this month, you can use the next month, or the one after.
 
 You can request an increase in your allowance if you feel the current one doesn't cover all the expenses for you. You can spend a few months of future allowance balance. The maximum allowance balance you can keep is 18 months. That said, it's smart to keep at least a few months allowance, just in case something breaks.
+
+##### What about those Niteans that receive their salary in USD?
+
+In case you live in a country that has their economy tied to USD mora than EUR,
+it is recommended that you choose to receive your salary in USD in order to
+decrease the risk of currency fluctuations affecting your base salary.
+
+In this case, your allowance will also come in USD. The exact amount of USD
+is calculated on 1st of January for every year, based on the current exchange
+rate, and rounded up to the nearest ten. For 2018, the USD allowance budget is
+$150 / month.
+
 
 ## Software Licenses
 


### PR DESCRIPTION
When explaining to @dmurko the recent changes in Scrooge we again, for the N-th time got stuck with how allowance is calculated. His understanding was that [the previous PR](https://github.com/niteoweb/handbook/pull/135) only applied to those that receive their salary in EUR.

A long debate ensued and we came out with a realization that everyone should receive their allowance budget in the currency they receive their salary in.

For example: I'm on a conference and want to buy dinner for an author of an Open Source library that we use a lot as a thank-you gesture. I remember that I have $20 left of allowance. Uhm, what is the current exchange rate to EUR? Ugh, I need to fire up my phone and check before I feel comfortable spending the allowance. Now imagine my allowance is always in my "base" currency. If the amount is 20€, that is not gonna change in value on me all of a sudden.

BTW, this decision was one of the reasons why [Scrooge needed a rewrite](https://github.com/niteoweb/scrooge/issues/24).