### PR TITLE
Add instructions on how to add story estimates

### DIFF
--- a/work-process/scrum.md
+++ b/work-process/scrum.md
@@ -83,7 +83,9 @@ One full time member on sprint should be able to do 10 Story Points. Estimates a
 
 In the *Vote* step, the Scrum Master updates the User Story with a `✋ [vote]` prefix to the title and assigns the team members from whom they want to receive Story Point estimations.
 
-Team members vote on a story by adding a comment with their story point estimation. To keep the estimate hidden so as to not influence anyone else's voting, we use the following code in a GitHub comment. Add this snippet to GitHub [saved replies](https://github.com/settings/replies) to reuse it.
+Team members vote on a story by adding a comment with their story point estimation to the User Story. The possible story point values are in the `Estimate` label drop-down on the right-hand side of a GitHub issue.
+
+So as to not influence anyone else's voting, we hide these estimate values in comments by using the following code snippet:
 
 ```
 <details>
@@ -92,7 +94,7 @@ Team members vote on a story by adding a comment with their story point estimati
 </details>
 ```
 
-The possible story points values can be seen in the `Estimate` label drop-down on the right-hand side of a GitHub issue.
+*Add this snippet to GitHub [saved replies](https://github.com/settings/replies) for reuse.*
 
 Once a team member has given their Story Point estimation, they should unassign themselves from the User Story.
 

--- a/work-process/scrum.md
+++ b/work-process/scrum.md
@@ -79,9 +79,22 @@ know we are paddling hard, but are we all paddling in the right direction?
 
 A [Story Point](https://agilefaq.wordpress.com/2007/11/13/what-is-a-story-point/) is an arbitrary measure used by Scrum teams to indicate the effort required to implement a User Story.
 
-One full time member on sprint should be able to do 10 Story Points. Estimates are based on [ZenHub estimates](https://www.zenhub.com/blog/software-estimates/) and the `Estimate` label in a User Story also shows available values.
+One full time member on sprint should be able to do 10 Story Points. Estimates are based on [ZenHub estimates](https://www.zenhub.com/blog/software-estimates/).
 
-In the *Vote* step, the Scrum Master updates the User Story with a `✋ [vote]` prefix to the title and assigns the team members from whom they want to receive Story Point estimations. Once a team member recieves a notification and gives their Story Point estimation, they should unassign themselves from the User Story.
+In the *Vote* step, the Scrum Master updates the User Story with a `✋ [vote]` prefix to the title and assigns the team members from whom they want to receive Story Point estimations.
+
+Team members vote on a story by adding a comment with their story point estimation. To keep the estimate hidden so as to not influence anyone else's voting, we use the following code in a GitHub comment. Add this snippet to GitHub [saved replies](https://github.com/settings/replies) to reuse it.
+
+```
+<details>
+  <summary>Story Point estimate</summary>
+  SP:
+</details>
+```
+
+The possible story points values can be seen in the `Estimate` label drop-down on the right-hand side of a GitHub issue.
+
+Once a team member has given their Story Point estimation, they should unassign themselves from the User Story.
 
 The Scrum Master then checks for concensus on the Story Points, sets the `Estimate` label to that value, removes the `✋ [vote]` prefix and moves the User Story to the top of the pipeline. The User Story is now ready to be included in the next sprint.
 

--- a/work-process/user-stories.md
+++ b/work-process/user-stories.md
@@ -9,14 +9,6 @@
   *  they assign people from whom they want to receive feedback for better definition of the User Story.
   * Once these people post their feedback, they unassign themselves from the User Story.
 - Once the Scrum Master and Product Owner agree that the User Story is well defined, they add ``✋ [vote]`` prefix to the title of the User Story. At that point, Scrum Master and/or Product Owner assign people from whom they want to receive User Story Points estimation. With this, online poker planning begins.
--  Assignees add their estimates in a comment with the following structure:
-```
-<details>
-  <summary>Click to see estimate</summary>
-  SP: (1, 2, 3, 5, 8, 13, 20, 100)
-</details>
-```
-This is a simple "spoiler alert" block that prevents implicitly affecting others opinion.
 - At the end of the online poker planning, Story Points are added to the User Story.
 - The User Story is now prepared to be moved to the top of the User Story Pyramid stack.
 

--- a/work-process/user-stories.md
+++ b/work-process/user-stories.md
@@ -9,6 +9,14 @@
   *  they assign people from whom they want to receive feedback for better definition of the User Story.
   * Once these people post their feedback, they unassign themselves from the User Story.
 - Once the Scrum Master and Product Owner agree that the User Story is well defined, they add ``✋ [vote]`` prefix to the title of the User Story. At that point, Scrum Master and/or Product Owner assign people from whom they want to receive User Story Points estimation. With this, online poker planning begins.
+-  Assignees add their estimates in a comment with the following structure:
+```
+<details>
+  <summary>Click to see estimate</summary>
+  SP: (1, 2, 3, 5, 8, 13, 20, 100)
+</details>
+```
+This is a simple "spoiler alert" block that prevents implicitly affecting others opinion.
 - At the end of the online poker planning, Story Points are added to the User Story.
 - The User Story is now prepared to be moved to the top of the User Story Pyramid stack.
 


### PR DESCRIPTION
Let's try this one more time.

Some discussion happened in https://github.com/niteoweb/handbook/pull/140 already. Then I was to fast to merge that PR and then [had to revert it](https://github.com/niteoweb/handbook/commit/07e938aab8759c883c7761d638ecf7e43016c428).

The general idea is good and I see Niteans already using it somewhere. What is missing is:
* instructions how to add "saved reply" so you have the snippet required for voting always at hand
* alternatively, instructions how to use dz0ny's Chrome extension for this
* approval at Retrospective so everyone knows about it