### PR TITLE
Update with correct meeting timezone

### DIFF
--- a/work-process/how-we-work.md
+++ b/work-process/how-we-work.md
@@ -4,9 +4,9 @@ Niteo is a distributed team spread around the World. While we rent office space 
 
 ## Communication
 
-Instant messaging is done through Slack on different channels (operations, support, development etc.). We have daily standups at 9AM UTC on Zoom where everyone has a minute or two to say what they’re working on and if they need any help.
+Instant messaging is done through Slack on different channels (operations, support, development etc.). We have [daily standups](standup.md) on Zoom, each morning, where everyone has a minute or two to say what they’re working on and if they need any help.
 
-Once a week, senior team members have [“catchups” (better known as 1-on-1)](../people/catchup-meetings.md) with everyone on the team to keep themselves in the loop.
+Twice a month, senior team members have [“catchups” (better known as 1-on-1)](../people/catchup-meetings.md) with everyone on the team to keep themselves in the loop.
 
 About once or twice a year we fly the whole team somewhere nice and we’ll have an “IRL” (in-real-life) meetup. Here we discuss company status, projects and the future in a group setting. IRLs normally happen in January and in July, perfect timing to review the (half-)year. Every Nitean is encouraged to attend in person, but we provide remote access as well. It's OK to remotely attend an IRL every now and then, but generally we expect everyone to be there in person.
 

--- a/work-process/scrum.md
+++ b/work-process/scrum.md
@@ -1,8 +1,8 @@
 # Scrum
 
-Sprint length: two weeks.
-
-Story Points commitment: 8 for each full-time member on the sprint and at least 25% of total commitment reserved for bugfixes and cleanup.
+ * Sprint length: two weeks.
+ * Story Points commitment: 8 for each full-time member on the sprint and at least 25% of total commitment reserved for bugfixes and cleanup.
+ * Sprint meeting times: Same as [daily standup](standup.md)
 
 User Stories with the highest story points are assigned and started first. That way simpler User Stories without champions can be worked on in the last days of the sprint by anyone who finished their own early.
 
@@ -15,13 +15,13 @@ For each sprint, a new milestone is created with name `Sprint #X` where `X` is t
 
 ## Schedule
 
-Our sprints start on a Wednesday 9am UTC with the [Sprint Planning](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_planning) meeting. They end on the Tuesday two weeks later with [Sprint Review and Sprint Retrospective](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_review_and_retrospective) meetings held at 10am CEST.
+Our sprints start on a Wednesday morning with the [Sprint Planning](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_planning) meeting. They end on the Tuesday morning two weeks later with [Sprint Review and Sprint Retrospective](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_review_and_retrospective) meetings.
 
 The last Monday morning of the Sprint everyone should open up the Kanban Board and ask themselves: "How can I help close whatever is still opened?". Repeat the same after lunch and on Tuesday morning.
 
-On the Wednesday in the middle of the sprint we hold the <a name="product_backlog_refinement_meeting"></a>[Product Backlog Refinement](https://en.wikipedia.org/wiki/Scrum_(software_development)#Backlog_refinement) meeting at 10am CEST.
+On the Wednesday in the middle of the sprint we hold the <a name="product_backlog_refinement_meeting"></a>[Product Backlog Refinement](https://en.wikipedia.org/wiki/Scrum_(software_development)#Backlog_refinement) meeting.
 
-All other days we hold the [Daily Standup](https://en.wikipedia.org/wiki/Scrum_(software_development)#Daily_scrum) meeting at 10am CEST.
+All other weekday mornings we hold the [daily standup](standup.md) meeting.
 
 For each new sprint the Scrum Master will create an operations sprint release that is used to store the User Story screencast demos. The template for this release is copied from [RELEASE_TEMPLATE.md](https://github.com/niteoweb/operations/raw/master/.github/RELEASE_TEMPLATE.md) in the operations repo.
 

--- a/work-process/standup.md
+++ b/work-process/standup.md
@@ -1,20 +1,22 @@
-# Daily Stand Up Meeting
+# Daily Standup Meeting
 
 ## Overview
-Daily stand up meetings are short meetings every day where we go over the work done in the last day and to be done the same/next day. It is also where we discuss any blockers and where project managers can keep a tab on work load.
 
- 
+[Daily standup] meetings are short meetings every day where we go over the work done on the previous day and to be done the same/next day. It is also where we discuss any blockers and where project managers can keep a tab on workload.
+
+
 ## Instructions
-Every day at 9AM UTC (10AM CET) we have a stand up meeting on [Zoom.us](https://zoom.us). You need the sofware and an account with email @niteo.co. If you have issues connecting or have a poor internet connection but still want to join, you can [phone-in to a local number](https://zoom.us/zoomconference). You will need the meeting ID which is always the same and seen on #operations channel when standup starts.
 
-One by one we'll go over the things done in the last day, things to be done and any blockers anyone has and resolve them. If there was a new feature published, this should be mentioned so people can update their work flows if it concerns them. 
+Every weekday morning at [10 A.M. CET/CEST](#timezones) we have a standup meeting on [Zoom](https://zoom.us). You need the software and an account with email `@niteo.co`. If you have issues connecting or have a poor internet connection but still want to join, you can [phone-in to a local number](https://zoom.us/zoomconference). You will need the meeting ID which is always the same and announced in the `#operations` channel before standup starts.
 
-If you're missing that day (conference and vacation excluded), add a note in #working-on Slack channel.
+One by one we'll go over the things done in the last day, things to be done and any blockers anyone has and resolve them. If there was a new feature published, this should be mentioned so people can update their workflows if it concerns them.
 
-We start gathering in our Hangout room 10 minutes before standup, to have some chit-chat and to catchup with each other. If you are finishing up something, by all means continue to do so until standup starts, but if you can, join in and share how your evening was and what great movie/concert/meme you saw recently. The Stand Up starts at 10:00 CET sharp! 
+If you're missing that day, add a note in the `#out-of-office` Slack channel.
 
-Since we are a remote-first team we don't get to meet in person very often. So to get at least a bit of social vibes across, please turn on your camera during the Stand Up. If possible, do stand up. It helps us to be concise and to the point. By all means, refrain from doing other things (browsing, doing support, etc.) during the meeting -- it rarely takes more than 15 minutes and we should all pay attention to everyone else for this period. 
- 
+We start gathering in the meeting room about 10 minutes before standup, to have some chit-chat and to catch up with each other. If you are finishing up something, by all means, continue to do so until standup starts, but if you can, join in and share how your evening was and what great movie/concert/meme you saw recently. The standup will start sharp so be on time!
+
+Since we are a remote-first team we don't get to meet in person very often. So to get a few of the social vibes across, please turn on your camera during the standup. If possible, do stand up. It helps us to be concise and to the point. Try to refrain from doing other things (browsing, doing support, etc.) during the meeting -- it rarely takes more than 15 minutes and we should all pay attention to everyone else for this period.
+
 
 ## Checklist
 
@@ -25,3 +27,11 @@ Before the meeting, take a minute to note:
 * Any blockers or help you need with tasks.
 * New features that were published and people should know about.
 * Turn on your camera. Disable any distractions, don't do anything else during the Stand Up.
+
+## Timezones
+
+Normal references to times, across the company, are made using [UTC], however, the daily morning meeting time needs to account for daylight savings time and the locations of Niteans around the world, from U.K. to the Philippines. Therefore to keep everyone's local meeting time between 9 A.M. and 5 P.M. the meeting timezone is set to CET ([Central European Time]) or CEST (Central European Summer Time), during summer months.
+
+[Daily standup]: https://en.wikipedia.org/wiki/Scrum_(software_development)#Daily_scrum
+[Central European Time]: https://en.wikipedia.org/wiki/Central_European_Time
+[UTC]: https://en.wikipedia.org/wiki/Coordinated_Universal_Time

--- a/work-process/work-process.md
+++ b/work-process/work-process.md
@@ -13,9 +13,9 @@ Our work process is based on [Scrum](https://en.wikipedia.org/wiki/Scrum_(softwa
 
 ## Schedule
 
- * Every weekday at 9am UTC we hold a [Daily Standup](https://en.wikipedia.org/wiki/Scrum_(software_development)#Daily_scrum) meeting.
+ * Every weekday morning we hold a [daily standup](standup.md) meeting.
 
-Sprint meetings replace the Daily Standup on these days:
+Sprint meetings replace the daily standup on these days:
 
  * A Wednesday is the start of a Sprint with [Sprint Planning](scrum.md#Sprint_Planning).
  * The Tuesday, two weeks later, marks the end of the Sprint with a [Sprint Retrospective](scrum.md#Sprint_Retrospective).


### PR DESCRIPTION
Clarification was required for the morning standup meetings and the
reasoning needed noting down.

Daily standup page updated with correct meeting time of 10 AM CET. In
addition a paragraph about timezone and how we came to the decision of
the morning meeting time.

References to the specific standup meeting time were removed from all
pages, replaced with link to standup.md page. This is so that the
meeting time/timezone need only be changed in one location in future.

Cleanup spelling, grammar and other small details.