### PR TITLE
Never un-assign Niteans from in-progress stories

### DIFF
--- a/work-process/scrum.md
+++ b/work-process/scrum.md
@@ -17,7 +17,7 @@ For each sprint, a new milestone is created with name `Sprint #X` where `X` is t
 
 Our sprints start on a Wednesday morning with the [Sprint Planning](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_planning) meeting. They end on the Tuesday morning two weeks later with [Sprint Review and Sprint Retrospective](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_review_and_retrospective) meetings.
 
-The last Monday morning of the Sprint everyone should open up the Kanban Board and ask themselves: "How can I help close whatever is still opened?". Repeat the same after lunch and on Tuesday morning.
+The last Monday morning of the Sprint everyone should open up the Scrum Board and ask themselves: "How can I help close whatever is still opened?". Repeat the same after lunch and on Tuesday morning.
 
 On the Wednesday in the middle of the sprint we hold the <a name="product_backlog_refinement_meeting"></a>[Product Backlog Refinement](https://en.wikipedia.org/wiki/Scrum_(software_development)#Backlog_refinement) meeting.
 
@@ -30,7 +30,7 @@ For each new sprint the Scrum Master will create an operations sprint release th
 
 Some of ideas are taken from https://colloq.io/blog/the-tools-we-use-to-stay-afloat.
 
-Our Kanban Board is at https://github.com/niteoweb/operations/#boards. By clicking on the `Show Menu` you get an additional sidebar that displays the main information about the sprint, such as the **Sprint Goal**, our capacity for the sprint, committed story points and the **Burndown Chart**.
+Our Scrum Board is at https://github.com/niteoweb/operations/#boards. By clicking on the `Show Menu` you get an additional sidebar that displays the main information about the sprint, such as the **Sprint Goal**, our capacity for the sprint, committed story points and the **Burndown Chart**.
 
 GitHub checkboxes are often utilized in creating mini-tasks for User Stories. Since there is no history on who clicked on what checkbox and when, always add a comment about the change made everytime a checkbox is ticked.
 

--- a/work-process/user-stories.md
+++ b/work-process/user-stories.md
@@ -11,6 +11,8 @@
 - Once the Scrum Master and Product Owner agree that the User Story is well defined, they add ``✋ [vote]`` prefix to the title of the User Story. At that point, Scrum Master and/or Product Owner assign people from whom they want to receive User Story Points estimation. With this, online poker planning begins.
 - At the end of the online poker planning, Story Points are added to the User Story.
 - The User Story is now prepared to be moved to the top of the User Story Pyramid stack.
+- On Sprint Planning meeting we choose which User Stories get included in the new sprint and we assign champions to them. From this point on, noone should be unassigned from the story so we know who worked on what when the sprint ends.
+- When the Champion deems the story done, they move it to the `Review` column. Scrum Master and Product Owner verify work was done as expected and move the Story to column `Done`.
 
 **Important:**
 
@@ -19,6 +21,7 @@
     - Vote on Story Points
     - Champion working on the User Story
 * Unassign yourself when you have done the above task you were assigned.
+* If the User Story is included into the current sprint and is already in progress, never unassign anyone. This allows us to see who worked on what even when the sprint ends.
 
 
 ## Writing User Stories


### PR DESCRIPTION
Currently, it's really hard to do work reviews because when I go to `Closed` column, all stories are assigned to @karantan who did the review. But I need to see who worked on what. This PR addresses said shortcoming in our process by:
* never assigning @karantan just for story review -- these stories already show up in the `Review` column in ZenHub,
* never un-assign anyone when story is already in progress.