### PR TITLE
Rename GrooveHQ to Groove

### DIFF
--- a/company/security.md
+++ b/company/security.md
@@ -96,7 +96,7 @@ You can use the [HTTPS-Everywhere] browser extension to ensure HTTPS versions of
 
 Sharing customer data such as lists of email addresses should be done using either [Resilio] or [Signal] so that no-one else has access to these private details.
 
-To share individual customer details you can securely reference them by using their application ID or customer issue ticket (e.g. GrooveHQ).
+To share individual customer details you can securely reference them by using their application ID or customer issue ticket (e.g. Groove).
 
 Sending unencrypted or plain text customer data using insecure services such as Slack or GitHub is a direct violation of our Terms of Service where we promise we won't share users' information with third parties.
 

--- a/roles/everyone-on-support.md
+++ b/roles/everyone-on-support.md
@@ -15,11 +15,11 @@ In the end, we are working for our customers, and having everyone involved in th
   * [Support Tools](https://github.com/niteoweb/support/blob/master/EBN/support-tools-and-processes.md)
   * [Support Issues Checklist](https://github.com/niteoweb/support/blob/master/EBN/support-issues-checklist.md)
   * [Blog Problems Checklist](https://github.com/niteoweb/support/blob/master/EBN/blog-problems-checklist.md)
-* We use [GrooveHQ](https://niteo.groovehq.com/) for handling support emails. For EOS, we have a predefined account which you'll need to personalize when you're on duty. Login credentials are on 1Password under *Team* vault. Go to *Edit Profile page* and update the *Name* field to your personal name. Leave the username as is (@niteo). Your name will not be reflected in UI immediately so you need to log out and log back in.
-* After logging back in to GrooveHQ, you will see the list of all tickets with assigned agent next to it. You can start working on any of the unassigned ones.
+* We use [Groove](https://niteo.groovehq.com/) for handling support emails. For EOS, we have a predefined account which you'll need to personalize when you're on duty. Login credentials are on 1Password under *Team* vault. Go to *Edit Profile page* and update the *Name* field to your personal name. Leave the username as is (@niteo). Your name will not be reflected in UI immediately so you need to log out and log back in.
+* After logging back in to Groove, you will see the list of all tickets with assigned agent next to it. You can start working on any of the unassigned ones.
 * On the sidebar, you can track list of all tickets assigned to you by clicking on *My New & Open*.
 * Everyone has *Staff* access to the EBN app, this allows you to log into internal [*Blog Dashboard*](https://github.com/niteoweb/support/blob/master/EBN/blog-dashboard.md) app.
-* GrooveHQ integrates with Slack so we get a live stream of emails and responses. You can optionally join #support-emails channel if you want to follow support operations. We also have the #server-operations channel for server status and warnings.
+* Groove integrates with Slack so we get a live stream of emails and responses. You can optionally join #support-emails channel if you want to follow support operations. We also have the #server-operations channel for server status and warnings.
 * All support documents can be found in our [support repository](https://github.com/niteoweb/support/). Make sure you go through them regularly and suggest improvements where needed.
 
 ### II. Frequency

--- a/roles/support.md
+++ b/roles/support.md
@@ -1,6 +1,6 @@
 # Handling Support Requests
 
-Email support is managed by [GrooveHQ](https://niteo.groovehq.com/), a mail-based ticketing system. Customers send an email through a contact form or directly, and a support ticket is created.
+Email support is managed by [Groove](https://niteo.groovehq.com/), a mail-based ticketing system. Customers send an email through a contact form or directly, and a support ticket is created.
 
 Read everything we have on product websites (don’t forget the footer links), [Support repository](https://github.com/niteoweb/support/), our blogs and help centers – multiple times. Most questions visitors and members ask are answered on these pages.
 
@@ -42,7 +42,7 @@ If something isn't clear, ask Dejan or Marbe. See our [policy on dealing with us
 
 Support related issues and topics are discussed on #support channel. This way everyone knows what's going on and can ping in on the topic. Avoid pinging coworkers in private since then others won't know what's going on.
 
-We also have the #support-emails channel for a live stream of GrooveHQ tickets and responses.
+We also have the #support-emails channel for a live stream of Groove tickets and responses.
 
 Server related issues, updates and warnings are posted on #server-operations channel.
 
@@ -61,13 +61,14 @@ Sample scenario: user wants you to change his login email.
 
 There are other scenarios but the general idea is that don't give anything to a user unless properly verified. One verification process is asking themm to log into their account then checking the logs for the login event.
 
-## Using GrooveHQ
+## Using Groove
 
 ### Canned Replies
 
-Pre-prepared replies to most common questions are available from the GrooveHQ user interface. You can use them and edit them as necessary. You can also refer to our [support issues checklist](https://github.com/niteoweb/support/blob/master/EBN/support-issues-checklist.md).
+Pre-prepared replies to most common questions are available from the Groove user interface. You can use them and edit them as necessary. You can also refer to our [support issues checklist](https://github.com/niteoweb/support/blob/master/EBN/support-tickets.md).
 
-If you have the need to create a new canned reply, you can do so by clicking Settings in top right corner of GrooveHQ, and then under Ticketing, click Canned Replies.
+
+If you have the need to create a new canned reply, you can do so by clicking Settings in top right corner of Groove, and then under Ticketing, click Canned Replies.
 
 ### Submit Statuses
 
@@ -75,7 +76,7 @@ Regular replies are always ‘Submit as Closed’. If there is still something y
 
 ### Labels
 
-We want to have a quantifiable data of user issues and requests received on Groove so we [tag the tickets](https://github.com/niteoweb/support/blob/master/EBN/support-tickets.md). 
+We want to have a quantifiable data of user issues and requests received on Groove so we [tag the tickets](https://github.com/niteoweb/support/blob/master/EBN/support-tickets.md).
 
 ### Spam Emails
 

--- a/work-process/how-we-work.md
+++ b/work-process/how-we-work.md
@@ -16,7 +16,7 @@ In addition there are ad-hoc in-person meetups that happen about once or twice a
 
 We work in 2-week Scrum Sprints described in detail in [Work Process](work-process.md).
 
-Project and task management is currently done with [GitHub](https://github.com/) and [ZenHub](https://www.zenhub.com/). Support handles tickets through [GrooveHQ](https://www.groovehq.com). We also have an internal document system (intranet) we call “Intra”, running on [Plone](https://plone.org/), where all our company processes and documents are stored.
+Project and task management is currently done with [GitHub](https://github.com/) and [ZenHub](https://www.zenhub.com/). Support handles tickets through [Groove](https://www.groovehq.com). We also have an internal document system (intranet) we call “Intra”, running on [Plone](https://plone.org/), where all our company processes and documents are stored.
 
 We track cash flow with [Xero](https://www.xero.com/). Finance reports are published to intranet on a monthly basis and are viewable to all full-time team members.
 


### PR DESCRIPTION
Although the website is groovehq.com the company is Groove and across
their website and documentation it is Groove not GrooveHQ.