### PR TITLE
Cleanup capilization in work-process pages

### DIFF
--- a/work-process/how-we-work.md
+++ b/work-process/how-we-work.md
@@ -1,4 +1,4 @@
-# How We Work
+# How we work
 
 Niteo is a distributed team spread around the World. While we rent office space in Ljubljana, Slovenia, most of us work remotely. Here's a quick overview of how we work and communicate.
 
@@ -8,13 +8,13 @@ Instant messaging is done through Slack on different channels (operations, suppo
 
 Twice a month, senior team members have [“catchups” (better known as 1-on-1)](../people/catchup-meetings.md) with everyone on the team to keep themselves in the loop.
 
-About once or twice a year we fly the whole team somewhere nice and we’ll have an “IRL” (in-real-life) meetup. Here we discuss company status, projects and the future in a group setting. IRLs normally happen in January and in July, perfect timing to review the (half-)year. Every Nitean is encouraged to attend in person, but we provide remote access as well. It's OK to remotely attend an IRL every now and then, but generally we expect everyone to be there in person.
+About once or twice a year we fly the whole team somewhere nice and we’ll have an *IRL* (in-real-life) meetup. Here we discuss company status, projects and the future in a group setting. IRLs normally happen in January and in July, perfect timing to review the (half-)year. Every Nitean is encouraged to attend in person, but we provide remote access as well. It's OK to remotely attend an IRL every now and then, but generally we expect everyone to be there in person.
 
 In addition there are ad-hoc in-person meetups that happen about once or twice a month, as needed. Some of us might get together to watch a talk at a local conference or we go to lunch together to discuss project work.
 
-## Project and Company Management
+## Project and company management
 
-We work in 2-week Scrum Sprints described in detail in [Work Process](work-process.md).
+We work in 2-week Scrum Sprints described in detail in the [work process](work-process.md) document.
 
 Project and task management is currently done with [GitHub](https://github.com/) and [ZenHub](https://www.zenhub.com/). Support handles tickets through [Groove](https://www.groovehq.com). We also have an internal document system (intranet) we call “Intra”, running on [Plone](https://plone.org/), where all our company processes and documents are stored.
 
@@ -28,6 +28,6 @@ Niteo runs several SaaS projects, serving a few thousand customers. We use sever
 
 And even if we do push buggy code to production, we only push it to a fraction of users to minimize impact. The outcomes are great: happy users, since they get features and fixes fast. And maybe even more importantly, happy developers, since the code is actually being used minutes after being merged rather than being stuck in a bureaucratic production deployment workflow. Nejc has [given](https://vimeo.com/110423315) [numerous](https://www.youtube.com/watch?v=HsGLLGeXFOU) [talks](https://www.youtube.com/watch?v=4GZcW19c4GM) on the subject.
 
-## Setting Goals and Deciding What To Work On
+## Setting goals and deciding what to work on
 
 We subscribe to the [12-Week Year](https://12weekyear.com/) philosophy for planning and goals. Every beginning of the quarter we review what we’ve done and if we hit all goals. Then we plan sprints for the next 12 weeks (everything is of course viewable on our intranet). The time interval is just short enough for actual week-to-week plans while also being long enough to get things done.

--- a/work-process/next-task.md
+++ b/work-process/next-task.md
@@ -1,4 +1,4 @@
-# Find Your Next Task
+# Find your next task
 
 We do most of our work through sprints so if you are in one, make sure you are completing those tasks first since they are our current focus. If for some reason you are not in the sprint, because of onboarding or finished your tasks, follow the steps below.
 
@@ -6,15 +6,15 @@ If all else is completed, you can always read a book, take an online course or j
 
 ## Developers
 
- - Go through our [Zenhub Backlog](https://github.com/niteoweb/operations/issues#boards). Choose a task that you like and is not on a sprint then ask the Scrum Master if you can start working on it.
+ - Go through issues in our [backlog]. Choose a task that you like and if is not on a sprint then ask the Scrum master if you can start working on it.
  - Search the codebase and documentation for "TODO", "XXX" and similar strings. Try to understand why it's there and create an issue for it. If you like the task, you can start working on it immediately.
 
-## DevOps and Support
+## DevOps and support
 
  - First focus on whether our systems are running smoothly and that all our customers' issues have been resolved and answered.
- - Review our [Handbook](https://github.com/niteoweb/handbook) and [Intra](https://intra.niteo.co/) documents, updating as necessary.
+ - Review our [handbook] and [intra]) documents, updating as necessary.
  - If you are DevOps and have had no tasks for some time, you can join the next sprint.
- - If you are Support and have had a slow few days, start reading on how we could improve our support. This may include improving our processes or rewriting our responses.
+ - If you are support and have had a slow few days, start reading on how we could improve our support. This may include improving our processes or rewriting our responses.
 
 ## Marketing
 
@@ -22,5 +22,9 @@ If all else is completed, you can always read a book, take an online course or j
 
 ## Operations
 
- - Review our [Handbook](https://github.com/niteoweb/handbook) and [Intra](https://intra.niteo.co/) documents, updating as necessary.
+ - Review our [handbook] and [intra] documents, updating as necessary.
  - Ask people what are the current issues they are facing and how we could resolve them.
+
+[backlog]: https://github.com/niteoweb/operations/issues#boards
+[handbook]: https://github.com/niteoweb/handbook
+[intra]: https://intra.niteo.co/

--- a/work-process/scrum.md
+++ b/work-process/scrum.md
@@ -1,52 +1,52 @@
 # Scrum
 
  * Sprint length: two weeks.
- * Story Points commitment: 8 for each full-time member on the sprint and at least 25% of total commitment reserved for bugfixes and cleanup.
+ * Story points commitment: 10 for each full-time member on the sprint. The total team commitment has at least 25% reserved for bugfixes and cleanup.
  * Sprint meeting times: Same as [daily standup](standup.md)
 
-User Stories with the highest story points are assigned and started first. That way simpler User Stories without champions can be worked on in the last days of the sprint by anyone who finished their own early.
+User stories with the highest story points are assigned and started first. That way simpler user stories without champions can be worked on in the last days of the sprint by anyone who finished their own early.
 
-User Stories that are dependent on each other should be merged into one bigger user story. This kind of user stories can have 2 champions.
+User stories that are dependent on each other should be merged into one bigger user story. This kind of user stories can have 2 champions.
 
 Support tasks take priority over sprint for support and DevOps team.
 
-For each sprint, a new milestone is created with the name `Sprint #X` where `X` is the number of the sprint (e.g. `Sprint #4`). On SCRUM sprint planning each User Story that is added to the planning sprint must be also added to the new milestone. With this ZenHub will automatically generate Burndown chart and we avoid having an additional label (`Sprint #X` label).
+For each sprint, a new milestone is created with the name `Sprint #X` where `X` is the number of the sprint (e.g. `Sprint #4`). On Scrum sprint planning each user story that is added to the planning sprint must be also added to the new milestone. With this ZenHub will automatically generate a burndown chart and we avoid having an additional label (`Sprint #X` label).
 
 
 ## Schedule
 
-Our sprints start on a Wednesday morning with the [Sprint Planning](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_planning) meeting. They end on a Tuesday morning two weeks later with [Sprint Review and Sprint Retrospective](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_review_and_retrospective) meetings.
+Our sprints start on a Wednesday morning with the [sprint planning](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_planning) meeting. They end on a Tuesday morning two weeks later with [sprint review and sprint retrospective](https://en.wikipedia.org/wiki/Scrum_(software_development)#Sprint_review_and_retrospective) meetings.
 
-The last Monday morning of the Sprint everyone should open up the Scrum Board and ask themselves: "How can I help close whatever is still opened?". Repeat the same after lunch and on Tuesday morning.
+The last Monday morning of the sprint everyone should open up the Scrum board and ask themselves: "How can I help close whatever is still opened?". Repeat the same after lunch and on Tuesday morning.
 
 On the Wednesday in the middle of the sprint we hold the <a name="product_backlog_refinement_meeting"></a>[Product Backlog Refinement](https://en.wikipedia.org/wiki/Scrum_(software_development)#Backlog_refinement) meeting.
 
 All other weekday mornings we hold the [daily standup](standup.md) meeting.
 
-For each new sprint, the Scrum Master will create an operations sprint release that is used to store the User Story screencast demos. The template for this release is copied from [RELEASE_TEMPLATE.md](https://github.com/niteoweb/operations/raw/master/.github/RELEASE_TEMPLATE.md) in the operations repo.
+For each new sprint, the Scrum master will create an operations sprint release that is used to store the user story screencast demos. The template for this release is copied from [RELEASE_TEMPLATE.md](https://github.com/niteoweb/operations/raw/master/.github/RELEASE_TEMPLATE.md) in the operations repo.
 
 
 ## Scrum on GitHub
 
 Some of the ideas are taken from https://colloq.io/blog/the-tools-we-use-to-stay-afloat.
 
-Our Scrum Board is at https://github.com/niteoweb/operations/#boards. By clicking on the `Show Menu` you get an additional sidebar that displays the main information about the sprint, such as the **Sprint Goal**, our capacity for the sprint, committed story points and the **Burndown Chart**.
+Our Scrum board is at https://github.com/niteoweb/operations/#boards. By clicking on the `Show Menu` you get an additional sidebar that displays the main information about the sprint, such as the *sprint goal*, our capacity for the sprint, committed story points and the *burndown chart*.
 
-GitHub checkboxes are often utilized in creating mini-tasks for User Stories. Since there is no history on who clicked on what checkbox and when always add a comment about the change made everytime a checkbox is ticked.
+GitHub checkboxes are often utilized in creating mini-tasks for user stories. Since there is no history on who clicked on what checkbox and when always add a comment about the change made everytime a checkbox is ticked.
 
 
-## Scrum Recommendations
+## Scrum recommendations
 
 After issue/user story/pull request is getting close to being completed people should go on zoom and discuss what else needs to be fixed. We don't want to see long PR discussions on GitHub. The **author** of the issue/user story/pull request should ping people on slack and get them on zoom to polish things.
 
 Every user story that first needs additional research should have automatically higher story points.
 
-Every day on stand-up scrum master should screen share and go through all the user stories that are *in progress*. He/She should ask the team `What can we close today?`.
+Every day on stand-up the Scrum master should screen share and go through all the user stories that are *in progress*. They should ask the team `What can we close today?`.
 
-Developers should be more involved in marketing/support related user stories. When a user story is created the author should assign a developer (one or more) from whom he/she thinks he/she will be able to get the technical details about the user story. Then that developer (one or more) should update the detailed technical description of the user story. Developers should also try to find different, easier solutions to the problem that this user story will solve, and present them to the author of the user story.
+Developers should be more involved in marketing/support related user stories. When a user story is created the author should assign a developer (one or more) from whom they think they will be able to get the technical details about the user story. Then that developer (one or more) should update the detailed technical description of the user story. Developers should also try to find different, easier solutions to the problem that this user story will solve, and present them to the author of the user story.
 
 
-## Sprint Retrospective
+## Sprint retrospective
 
 After each sprint, we have a retrospective, where we think about:
 
@@ -56,29 +56,29 @@ After each sprint, we have a retrospective, where we think about:
 
 This is also the time to bring up any other comments about the work process in general.
 
-We look at how many Story Points we assigned, how many were done and the distribution between the departments and types of User Stories.
+We look at how many story points we assigned, how many were done and the distribution between the departments and types of user stories.
 
-The Scrum Master will create a new [retrospective issue](https://github.com/niteoweb/operations/issues/new?template=retrospective.md&title=Retrospective%20for%20Sprint%20#) before each retrospective. This issue has a template that serves as a checklist for the meeting and helps the Scrum Master write up a brief report afterward.
+The Scrum master will create a new [retrospective issue](https://github.com/niteoweb/operations/issues/new?template=retrospective.md&title=Retrospective%20for%20Sprint%20#) before each retrospective. This issue has a template that serves as a checklist for the meeting and helps the Scrum master write up a brief report afterward.
 
 
-## Alignment Meeting
+## Alignment meeting
 
-15 minutes after the [Sprint Retrospective] we hold another meeting. Attendance on this one is optional, only those interested in the general direction the company is taking normally attend. That said, every Nitean is welcome to participate.
+15 minutes after the [sprint retrospective] we hold another meeting. Attendance on this one is optional, only those interested in the general direction the company is taking normally attend. That said, every Nitean is welcome to participate.
 
 We go through the [cancellation reasons of EBN users](https://github.com/niteoweb/support/blob/master/EBN/cancellation-analysis.md). Since they are our primary customers, we want to know why they're leaving and check if there are any actionable reasons.
 
-Then we go through all [Cardinal Dashboards] and check for trends that need addressing.
+Then we go through all [cardinal dashboards] and check for trends that need addressing.
 
 Finally, we look over the quarterly goals to determine how we are achieving them and to give us an idea of what should be included in the following day's sprint planning session.
 
-The main purpose of the Alignment Meeting is to adjust our compasses so that we will select the correct User Stories in the Sprint Planning meeting coming the next day. We
+The main purpose of the alignment meeting is to adjust our compasses so that we will select the correct user stories in the sprint planning meeting coming the next day. We
 know we are paddling hard, but are we all paddling in the right direction?
 
 
 ## Recurring tasks
 
-There are a bunch of tasks we have to do every month/quarter/year. To make sure they get assigned enough time for proper execution, we include them in sprints as User Stories. The only difference is, they don't need User Story demo recordings since they happen so often and are repetitive.
+There are a bunch of tasks we have to do every month/quarter/year. To make sure they get assigned enough time for proper execution, we include them in sprints as user stories. The only difference is, they don't need user story demo recordings since they happen so often and are repetitive.
 
 For every month/quarter that a recurring task is required we (re)open the issue and create a comment for the new month/quarter.
 
-On every Sprint Planning meeting, we go through the [list of User Stories for recurring tasks](https://github.com/niteoweb/operations/issues?utf8=%E2%9C%93&q=+label%3ARecurring+) and we add those that apply to the sprint first.
+On every sprint planning meeting, we go through the [list of user stories for recurring tasks](https://github.com/niteoweb/operations/issues?utf8=%E2%9C%93&q=+label%3ARecurring+) and we add those that apply to the sprint first.

--- a/work-process/work-process.md
+++ b/work-process/work-process.md
@@ -1,14 +1,14 @@
-# Work Process
+# Work process
 
 ## Scrum process
 > *Main document: [Scrum](scrum.md)*
 
 Our work process is based on [Scrum](https://en.wikipedia.org/wiki/Scrum_(software_development)), but modified to suit to our specific needs:
 
- * We are our own Product Owners, as we have no customer projects.
+ * We are our own *product owners*, as we have no customer projects.
  * We work asynchronously, so keep scheduled meetings to the bare minimum.
- * We schedule our work into two week long Sprints.
- * We manage our Sprints with GitHub and ZenHub.
+ * We schedule our work into two week long *sprints*.
+ * We manage our sprints with GitHub and ZenHub.
 
 
 ## Schedule
@@ -17,44 +17,44 @@ Our work process is based on [Scrum](https://en.wikipedia.org/wiki/Scrum_(softwa
 
 Sprint meetings replace the daily standup on these days:
 
- * A Wednesday is the start of a Sprint with [Sprint Planning](scrum.md#Sprint_Planning).
- * The Tuesday, two weeks later, marks the end of the Sprint with a [Sprint Retrospective](scrum.md#Sprint_Retrospective).
- * Then Wednesday, the next day, is usually the start of the next Sprint.
+ * A Wednesday is the start of a sprint with [sprint planning](scrum.md#Sprint_Planning).
+ * The Tuesday, two weeks later, marks the end of the sprint with a [sprint retrospective](scrum.md#Sprint_Retrospective).
+ * Then Wednesday, the next day, is usually the start of the next sprint.
 
 
-## Creating Issues and User Stories
-> *Main document: [Issues and User Stories](user-stories.md)*
+## Creating issues and user stories
+> *Main document: [Guide for user stories](user-stories.md)*
 
 Undefined issues are created in various repositories to track known problems. Issues that are created by Support are usually reactionary so stay in project-related repositories and are not included in sprints.
 
-When undefined issues from various repositories need to be moved into a Sprint, a well-defined User Story needs to be created for that issue. This can be done by the author of the issue, Scrum Master or Project Owner.
+When undefined issues from various repositories need to be moved into a sprint, a well-defined user story needs to be created for that issue. This can be done by the author of the issue, Scrum master or product owner.
 
-To create a new User Story, open an issue in [Operations repository](https://github.com/niteoweb/operations/issues) and use the supplied template. There are further details on writing the US in the [Issues and User Stories](user-stories.md) document.
+To create a new user story, open an issue in [operations repository](https://github.com/niteoweb/operations/issues) and use the supplied template. There are further details on writing the US in the [user stories](user-stories.md) document.
 
-## Pull Requests and Commits
+## Pull requests and commits
 
 > *Main article: [Git guide](../apps-we-use/git.md)*
 
-While working on User Stories we often need to change code or text that we keep in GitHub. These changes are done with [git commits](https://help.github.com/articles/github-glossary/#commit) and are presented to others for review as [Pull Requests](https://help.github.com/articles/about-pull-requests/).
+While working on user stories we often need to change code or text that we keep in GitHub. These changes are done with [git commits](https://help.github.com/articles/github-glossary/#commit) and are presented to others for review as [Pull Requests](https://help.github.com/articles/about-pull-requests/).
 
 To ensure that your commits and Pull Requests contain everything necessary for a successful review, read through the [Git](../apps-we-use/git.md) guide for the best practices.
 
 
-## Continual Improvement
+## Continual improvement
 
 Big cleanups (of code, documentation, or anything else) happen rarely. They are hard to organize, and to motivate for. Instead of doing big cleanups every few months (years?) when pain levels are high enough, we prefer to do constant tiny improvements with an approach called [Continual Improvement](https://en.wikipedia.org/wiki/Continual_improvement_process).
 
 For Niteo, this means that every Pull Request (except Priority Lane issues) should include at least one minor cleanup commit alongside the main PR commit. It does not need to be related to the main commit, it can be improvements for anything in the repo, however trivial. This can include code and documentation updates, typo fixes, or removal of something that no longer makes sense.
 
 
-## Urgent Production Fixes
+## Urgent production fixes
 
-If we need to fix an urgent bug, we use the Scrum Priority Lane approach: the User Story gets written and then if the Product Owner decides it really is urgent, the User Story is added to the top of WIP column and labeled with [Priority Lane](user-stories.md#scrum-labels) so that everyone knows it is an exceptional and urgent issue and the whole team needs to focus on getting it to column Done ASAP.
+If we need to fix an urgent bug, we use the Scrum *priority lane* approach: the user story gets written and then if the product owner decides it really is urgent, the user story is added to the top of 'In Progress' pipeline and labeled with [Priority Lane](user-stories.md#labels) so that everyone knows it is an exceptional and urgent issue and the whole team needs to focus on getting it completed as soon as possible.
 
 
-## Ongoing Tasks
+## Ongoing tasks
 
-Sometimes the result of a User Story is an agreement that we should do a certain task periodically, over a longer period of time. Such tasks are created in whichever repo is the most appropriate and labeled with [Ongoing](#label_ongoing) label.
+Sometimes the result of a user story is an agreement that we should do a certain task periodically, over a longer period of time. Such tasks are created in whichever repo is the most appropriate and labeled with [Ongoing](#label_ongoing) label.
 
 ## Useful Lists
 


### PR DESCRIPTION
A style based on wikipedia style guide is now being used in hanbook and
initial capitalization only applies to proper nouns or starting a
sentence so fix all instances on this page. Some examples of the new
correct usage within a sentence:

 - Scrum *not SCRUM*
 - Scrum master *not Scrum Master*
 - product owner *not Product Owner*
 - sprint *not Sprint*

Also included:
- Fixed full-time team member story point capacity to be 10.
- Fixed links and some small rewording.