### PR TITLE
Add a writing style guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This Handbook offers us an opportunity to clarify what Niteo is and how we opera
 
 ## Miscellaneous
 * [Security Policy](company/security.md)
-* [Style guide](company/style-guide.md)
+* [Writing style guide](company/writing-style-guide.md)
 * [Managing documentation](company/managing-docs.md)
 * [Glossary](glossary.md)
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ This Handbook offers us an opportunity to clarify what Niteo is and how we opera
 
 ## Miscellaneous
 * [Security Policy](company/security.md)
+* [Style guide](company/style-guide.md)
 * [Managing documentation](company/managing-docs.md)
 * [Glossary](glossary.md)
 

--- a/company/style-guide.md
+++ b/company/style-guide.md
@@ -1,0 +1,36 @@
+# Niteo writing style guide
+
+To mantain a simple concise style guide we have adopted the Wikipedia [Manual of Style] as our writing style for any kind of documentation or prose.
+
+Here are some of the common styles that must be followed when writing documentation:
+
+* Use [plain English] however even better is [Simplified English] to ensure accuracy.[1][plain English problems]
+* Spelling and grammar are in American English. Use [Grammarly] to keep your writing correct.
+* [Lists][MoS/Lists] should be sentence case
+* [Headings and titles][MoS Article titles] should be sentence case.
+* [Capital letters][MoS/Capital letters] should be used sparingly for the start of sentences, acronyms, proper nouns or trademarks. Common terms such as sprint, product owner, support are lowercase.
+
+Some further additions to be loosely followed:
+
+* Page length should be kept under 200 lines. Consider breaking into further pages if over this length.
+* Use a table of contents to help navigate the page.
+* Use [reference links] to put long URLs at the foot of the page instead of inline in the text. This helps with editing and version control diffs.
+
+Further Reference:
+  * [GitLab handbook](https://gitlab.com/gitlab-com/www-gitlab-com/tree/master/source/handbook)
+  * [Basecamp handbook](https://github.com/basecamp/handbook)
+  * [The Mayfield Handbook of Tecnhical & Scientific Writing](http://www.mhhe.com/mayfieldpub/tsw/home.htm)
+  * [plain language](https://www.plainlanguage.gov/guidelines/)
+  * [Sentence vs title case](https://www.snappysentences.com/sentence-case-v-title-case/)
+  * [Commonmark](https://spec.commonmark.org/current)
+
+[Grammarly]:https://www.grammarly.com
+[Manual of Style]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style
+[MoS/Lists]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Lists#Bulleted_lists
+[MoS Article titles]
+:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Article_titles,_headings,_and_sections
+[MoS/Capital letters]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Capital_letters
+[Simplified English]:https://simple.wikipedia.org/wiki/Simplified_English
+[Plain English]:https://en.wikipedia.org/wiki/Plain_English
+[plain English problems]:https://www.techscribe.co.uk/techw/plain-english-problems.htm
+[reference links]:https://spec.commonmark.org/0.28/#reference-link

--- a/company/writing-style-guide.md
+++ b/company/writing-style-guide.md
@@ -4,7 +4,7 @@ To mantain a simple concise style guide we have adopted the Wikipedia [Manual of
 
 Here are some of the common styles that must be followed when writing documentation:
 
-* Use [plain English] however even better is [Simplified English] to ensure accuracy.[1][plain English problems]
+* Use [plain English] however even better is [simplified English] to ensure accuracy. (See: [Plain English problems])
 * Spelling and grammar are in American English. Use [Grammarly] to keep your writing correct.
 * [Lists][MoS/Lists] should be sentence case
 * [Headings and titles][MoS Article titles] should be sentence case.
@@ -20,7 +20,7 @@ Some further additions to be loosely followed:
   * [GitLab handbook](https://gitlab.com/gitlab-com/www-gitlab-com/tree/master/source/handbook)
   * [Basecamp handbook](https://github.com/basecamp/handbook)
   * [The Mayfield Handbook of Tecnhical & Scientific Writing](http://www.mhhe.com/mayfieldpub/tsw/home.htm)
-  * [plain language](https://www.plainlanguage.gov/guidelines/)
+  * [Plain language](https://www.plainlanguage.gov/guidelines/)
   * [Sentence vs title case](https://www.snappysentences.com/sentence-case-v-title-case/)
   * [Commonmark](https://spec.commonmark.org/current)
 
@@ -32,5 +32,5 @@ Some further additions to be loosely followed:
 [MoS/Capital letters]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Capital_letters
 [Simplified English]:https://simple.wikipedia.org/wiki/Simplified_English
 [Plain English]:https://en.wikipedia.org/wiki/Plain_English
-[plain English problems]:https://www.techscribe.co.uk/techw/plain-english-problems.htm
+[Plain English problems]:https://www.techscribe.co.uk/techw/plain-english-problems.htm
 [reference links]:https://spec.commonmark.org/0.28/#reference-link

--- a/company/writing-style-guide.md
+++ b/company/writing-style-guide.md
@@ -1,4 +1,4 @@
-# Niteo writing style guide
+# Writing style guide
 
 To mantain a simple concise style guide we have adopted the Wikipedia [Manual of Style] as our writing style for any kind of documentation or prose.
 
@@ -16,7 +16,7 @@ Some further additions to be loosely followed:
 * Use a table of contents to help navigate the page.
 * Use [reference links] to put long URLs at the foot of the page instead of inline in the text. This helps with editing and version control diffs.
 
-Further Reference:
+## Further reference
   * [GitLab handbook](https://gitlab.com/gitlab-com/www-gitlab-com/tree/master/source/handbook)
   * [Basecamp handbook](https://github.com/basecamp/handbook)
   * [The Mayfield Handbook of Tecnhical & Scientific Writing](http://www.mhhe.com/mayfieldpub/tsw/home.htm)
@@ -24,11 +24,11 @@ Further Reference:
   * [Sentence vs title case](https://www.snappysentences.com/sentence-case-v-title-case/)
   * [Commonmark](https://spec.commonmark.org/current)
 
+
 [Grammarly]:https://www.grammarly.com
 [Manual of Style]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style
 [MoS/Lists]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Lists#Bulleted_lists
-[MoS Article titles]
-:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Article_titles,_headings,_and_sections
+[MoS Article titles]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style#Article_titles,_headings,_and_sections
 [MoS/Capital letters]:https://en.wikipedia.org/wiki/Wikipedia:Manual_of_Style/Capital_letters
 [Simplified English]:https://simple.wikipedia.org/wiki/Simplified_English
 [Plain English]:https://en.wikipedia.org/wiki/Plain_English


### PR DESCRIPTION
We needed a reference point for writing documentation so added a new
page with details of the style (heavily based on wikipedia style) that
should be used for any kind of writing within the company.

Refs: #125