### PR TITLE
New Slack channels structure & gently nudge Niteans towards more public messaging

### DIFF
--- a/2_Operations/apps.md
+++ b/2_Operations/apps.md
@@ -12,7 +12,7 @@ Our default mode of operation is to use public channels for all communication. Y
 
 However, questions such as "where can I find X", "how do I do Y" and "what is Z" should be posted into public channels. Since more Niteans can chip in you will get your answer faster.
 
-If you are on the receiving end of a question or message, that should really be posted in a public channel, reply with the following: `Hey! Let's take this to one of our public channels, so others can learn or chip in. I'll re-post and reply there!`
+If you are on the receiving end of a question or message, that should really be posted in a public channel, reply with the following: `Hey! Let's take this to one of our public channels, so others can learn or chip in. I'll re-post and reply there.`. 
 
 #### Channels
 

--- a/2_Operations/apps.md
+++ b/2_Operations/apps.md
@@ -4,7 +4,24 @@
 
 To start using Slack you will need to [sign up](https://join.slack.com/niteo/signup) to the company workspace using your `@niteo.co` email address. It is recommended that you install the [Slack app](https://slack.com/download) on your desktop and your phone so that you do not miss out on any messages directed to you or other informative communication. Please fill in your [Slack profile](https://niteo.slack.com/account/profile) with your details and ensure that the display name matches your GitHub handle and the Profile photo displays your full face.
 
-Once you're joined, join the channels `#operations`, `#watercooler`, `#out-of-office`, and any other channels that you find interesting.  
+Once you're joined, join the channels `#operations`, `#watercooler`, `#out-of-office`, and any other channels that you find interesting.
+
+#### Private vs. Public
+
+Our default mode of operation is to use public channels for all communication. Yes, sometimes you want to discuss something in person, or bounce an idea off of someone before writing to a public channel, and that's perfectly fine. Chit chat and  personal things, keep them private too.
+
+However, questions such as "where can I find X", "how do I do Y" and "what is Z" should be posted into public channels. Since more Niteans can chip in you will get your answer faster.
+
+If you are on the receiving end of a question or message, that should really be posted in a public channel, reply with the following: `Hey! Let's take this to one of our public channels, so others can learn or chip in. I'll re-post and reply there!`
+
+#### Channels
+
+Slack channels are separated into company-level and project-level channels. Projects start as discussions and ideas in company-level channels. When development and research takes off, projects get pushed into their own `#<project>` channel. Later on, when they start getting the first customers the project gets two more channels, `#<project>-dev` and `#<project>-support`, while the general discussions about the project are kept in `#<project>`. When the project grows even more, it gets even more specific channels. Click on the `Channels` heading in Slack's sidebar to see the list of active channels and their descriptions.
+
+How to know which channel to write to? Write to the most specific channel. If your topic does not have a dedicated channel, bubble up to the "parent" channel. Example:
+* I want to ask something about WooCart's codebase. WooCart does not (yet) have the `#woocart-dev` channel, so I "bubble up" to `#woocart` channel.
+* I want to share an implementation idea for [Docsy](http://docsy.org/). Docsy does not (yet) have the `#docsy` channel, so I "bubble up" to `#development` channel.
+
 
 #### Slack is Insecure Messaging
 
@@ -16,7 +33,7 @@ Slack can be a [big distraction](https://m.signalvnoise.com/is-group-chat-making
 
 ## Signal
 
-[Signal](https://signal.org/) is a secure end-to-end encrypted (E2EE) messaging application. We use it for confidential messages that should not be sent via email or Slack. To start using Signal you will require an Android phone or iPhone and a working phone number. 
+[Signal](https://signal.org/) is a secure end-to-end encrypted (E2EE) messaging application. We use it for confidential messages that should not be sent via email or Slack. To start using Signal you will require an Android phone or iPhone and a working phone number.
 
 #### Usage
 
@@ -44,9 +61,9 @@ Ask @zupo to create and send your personal OpenVPN configuration files.
 ##### Import configuration files:
 
 * **MacOS and Windows:** Double-click on an `.ovpn` file and follow the instructions.
-* **Ubuntu:** 
-  * Choose `Edit connections` from Network indicator. 
-  * Click `Add` then at the end of the list choose to `Import a saved VPN config` and locate the `.opvn` file to import. 
+* **Ubuntu:**
+  * Choose `Edit connections` from Network indicator.
+  * Click `Add` then at the end of the list choose to `Import a saved VPN config` and locate the `.opvn` file to import.
   * The new VPN should be available in the network indicator under `VPN Connections`.
 * **Command line:** To test or manually run OpenVPN with a config file: `openvpn --config eu.ovpn`
 
@@ -58,15 +75,15 @@ You can test that the Niteo VPN works correctly by visiting [Docs](http://docs.n
 
 ## Resilio
 
-Resilio is a secure BitTorrent-based Dropbox-like service for teams. 
+Resilio is a secure BitTorrent-based Dropbox-like service for teams.
 
 #### Installation and Configuration
 
-* Go to the [Resilio download page](https://www.resilio.com/individuals), click `Free Download` and `Download Sync Business`. 
+* Go to the [Resilio download page](https://www.resilio.com/individuals), click `Free Download` and `Download Sync Business`.
 * Enter our License key on `Settings` -> `License`. Ask @zupo to generate a License Link for you.
-* One of the Partners needs to share the `Niteo` folder with you. They do this by opening up Resilio and clicking the `Share` button for the `Niteo` folder and sending you the `Read & Write` link . 
+* One of the Partners needs to share the `Niteo` folder with you. They do this by opening up Resilio and clicking the `Share` button for the `Niteo` folder and sending you the `Read & Write` link .
 * When you click the link, Resilio should start up and add the shared folder to your device. If this does not happen, open Resilio and click the plus icon to manually enter the link.
-* It is important that the you turn `Selective Sync` ON. This tells Resilio to only download filenames to your machine, without the actual data, to save disk space. 
+* It is important that the you turn `Selective Sync` ON. This tells Resilio to only download filenames to your machine, without the actual data, to save disk space.
 
 
 #### Limitations


### PR DESCRIPTION
1. Discussion on Slack about splitting channels: https://niteo.slack.com/archives/C071TQ6LE/p1533126196000254
2. @dz0ny and I had a discussion about private vs. public in London and reached a decision (or so I understood it, correct me if I am wrong) that instead of keeping discussions one-on-one "for easier tracking if someone replies after 7 hours" we should:
  * split channels (first point)
  * use threads more

Update channels:
* [ ] rename #server-operations -> #ebn-server-operations
* [ ] remove #support-emails (we're switching to Intercom?)
* [ ] remove #articles
* [x] rename #k8s-events -> #woocart-k8s-events
* [ ] rename #support -> #ebn-support
  * [ ] merge https://github.com/niteoweb/ebn/pull/3677
  * [ ] merge https://github.com/niteoweb/support/pull/51
  * [ ] merge https://github.com/niteoweb/ebn-monitors/pull/14
  * [ ] merge https://github.com/niteoweb/cronly/pull/22
* [ ] rename #development -> #ebn-development
* [ ] create new #development channel