### PR TITLE
Update nitean recognition policy

### DIFF
--- a/5_People/nitean-recognition.md
+++ b/5_People/nitean-recognition.md
@@ -1,14 +1,14 @@
-# Nitean recognition
+# Nitean Recognition
 
 As Niteans, we believe in celebrating small wins and recognizing achievements. By enabling Nitean recognition, we're boosting each other's morale, enhancing engagement and communication, and improving the overall company culture.
 
-## Peer recognition
+## Peer Recognition
 
 To encourage peer recognition, we're using the [Bonus.ly](https://bonus.ly/) platform which enables Niteans to give each other micro-bonuses in the form of +1s. Big or small of an act, if it made you happy, recognize and reward it.
 
 We took a page from the head of Google’s People Operations, Laszlo Bock, and created our own version of the [_wall-of-happy_](https://plus.google.com/+LaszloBock/posts/UzxkRpkvyf7). Instead of a physical wall where kudos are printed out, we have a Slack channel `#recognition` where you can see a steady stream of kudos and reactions.
 
-Monitor the leaderboard on [Bonusly analytics page](https://bonus.ly/analytics/leaderboards).
+Monitor the leaderboard on the [Bonusly analytics page](https://bonus.ly/analytics/leaderboards).
 
 ## Policy
 
@@ -22,7 +22,7 @@ To give someone a bonus, use the format below.
 
 The more +1's (peer recognition) you get, the more points you collect. Other Niteans who want to acknowledge the recognition can also give their +1 by clicking `Add on this bonus?`.
 
-## Redeem your points
+## Redeeming Points
 
 To keep things interesting, Niteans can redeem their points from the [list of awesome rewards](https://bonus.ly/company/catalog_items?show=custom&country=SI) we have.
 


### PR DESCRIPTION
Updated the policy to reflect the new changes:
- each Nitean gets 30 points to give away every month
- updated slack channel
- trialists can start collecting points but only permanent Nitean can redeem
- defined new awards


On the fence whether the rewards list should be added to the handbook or not. Thoughts?