### PR TITLE
Add Easyblognetworks URL to the whitelist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,5 +20,6 @@ http://books.niteo.co,\
 http://videos.niteo.co,\
 https://github.com/issues/assigned,\
 https://github.com/orgs/niteoweb/teams,\
+https://github.com/niteoweb/easyblognetworks,\
 https://apps.rackspace.com/%0D%0A \
 --skip-save-results `find . -iname "*.md"`


### PR DESCRIPTION
Add `https://github.com/niteoweb/easyblognetworks` to the `linkchecker` whitelist
so it can be ignored as it is a private repository.

Ref: #208 