### PR TITLE
Add checking GitHub notifications to work process

### DIFF
--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -4,6 +4,7 @@
 ## Schedule
 
  * Every weekday morning we hold a daily standup meeting.
+ * Every weekday each Nitean needs to check GitHub notifications.
 
 Sprint meetings replace the daily standup on these days:
 

--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -4,7 +4,7 @@
 ## Schedule
 
  * Every weekday morning we hold a daily standup meeting.
- * Every weekday each Nitean needs to check GitHub notifications.
+ * Every weekday Niteans should check their [GitHub notifications](https://github.com/notifications) so that they don't miss things that involve them.
 
 Sprint meetings replace the daily standup on these days:
 


### PR DESCRIPTION
I saw that Niteans (mostly new Niteans) don't respond to GitHub ping
(i.e. when you mention them or assign them an issue) and that is because
they don't check their GitHub notifications.