### PR TITLE
Bonus 50% for booth/talk only for conference day

### DIFF
--- a/5_People/benefits.md
+++ b/5_People/benefits.md
@@ -38,7 +38,7 @@ The allowance bonus accounts for all the days you are away at the conference and
 * €40 ($50)/day for local conferences, in or near your home city.
 * €150 ($180)/day for international conferences.
 * 250€ ($300)/day for intercontinental conferences.
-* Bonus 50%/day if you give a 30-60min talk at the conference or tending our booth.
+* Bonus 50%/conference day if you give a 30-60min talk at the conference or tending our booth.
 
 Conferences count as working days (7.5h per day). Transport to conferences counts too (up to 7.5h per day).
 


### PR DESCRIPTION
If travel to conference requires additional days, those are not counted fro the 50% bonus.