### PR TITLE
Trialist salary every 2m 70-80-90%

### DIFF
--- a/5_People/onboarding.md
+++ b/5_People/onboarding.md
@@ -8,7 +8,7 @@ Congratulations on completing the interview process, and joining us here at Nite
 
 We don't believe in long interview processes with tricky questions and unrealistic tasks. We rather hire someone for a trial period to see if we fit nicely together.
 
-The trial period lasts somewhere between 3 to 6 months. Normally, the trialist receives roughly 70% of the salary others earn in a similar position (there can be exceptions). The salary is calculated based on hours done in a month.
+The trial period lasts somewhere between 3 to 6 months. The trialist receives 70% of the salary in the first two months, 80% in the next two months, and 90% after that. The salary is calculated based on hours done in a month.
 
 As a trialist you will not be included in [profit sharing](../people/profit-sharing.md) and other [benefits](../people/benefits.md), nor entitled to a [severance](../people/salary.md#lay-off--severance-policy) package.
 


### PR DESCRIPTION
This is proposed so that we have markers that show progression towards Permanent position.