### PR TITLE
Remove Alignment meeting and fix a few typos.

### DIFF
--- a/2_Operations/scrum.md
+++ b/2_Operations/scrum.md
@@ -19,7 +19,7 @@ For each sprint, a new milestone is created with the name `Sprint #X` where `X` 
 
 ## Daily Standup
 
-Daily standup meetings are short meetings every day where we go over the work done on the previous day and to be done the same/next day. It is also where we discuss any blockers and where project managers can keep a tab on workload. Every project has its own standup time.
+Daily standup meetings are short meetings every day where we go over the work done on the previous day and to be done the same/next day. It is also where we discuss any blockers and where project managers can keep a tab on workload. The order for Niteans on standups is alphabetically. So the person whose first name starts with `A` goes first. Every project has its own standup time.
 
 Turn on your camera during the standup. Try to refrain from doing other things (browsing, doing support, etc.) during the meeting -- it rarely takes more than 15 minutes and we should all pay attention to everyone else for this period.
 

--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -16,11 +16,10 @@ Sprint meetings replace the daily standup on these days:
    * 10:00 CE(S)T for the whole company in the Niteo Zoom room
    * followed immediately by separate plannings for Easy Blog Networks and WooCart, in their own Zoom rooms
    * followed by [Developers Session](#developers-session)
- * The **Tuesday**, two weeks later, marks the end of the sprint with a sprint retrospective and company alignment meeting.
-   * 10:00 CE(S)T for Niteo
-   * followed immediately by retrospective for Easy Blog Networks 
-   * 11:00 CE(S)T for WooCart
-   * 12:00 CE(S)T for Niteo Alignment Meeting
+ * The **Tuesday**, two weeks later, marks the end of the sprint with a sprint retrospective.
+   * 10:00 CE(S)T for EBN
+   * followed immediately by retrospective for WooCart
+   * 11:30 CE(S)T for Niteo
 
 The last Monday morning of the sprint everyone should open up the Scrum board and ask themselves: "How can I help close whatever is still opened?". Repeat the same after lunch and on Tuesday morning.
 
@@ -33,42 +32,36 @@ Our work process is based on [Scrum](https://en.wikipedia.org/wiki/Scrum_(softwa
  * Sprint length is two weeks.
  * Story points commitment: 10 for each full-time member on the sprint. The total team commitment has at least 25% reserved for bug fixes and cleanup.
 
-## Alignment Meeting
-
-After the sprint retrospective we hold another meeting. Attendance is optional but every Nitean is welcome to participate. Primarily we look over the quarterly goals to determine if we are achieving them and to give us an idea of what should be included in the following day's sprint planning session.
-
-The main purpose of the alignment meeting is to adjust our compasses so that we will select the correct user stories in the sprint planning meeting coming the next day. We know we are paddling hard, but are we all paddling in the right direction?
-
 ## Quarterly Review and Planning
 
-Every quarter we take time to review, reflect, and plan for the next quarter. There are three tasks for the Quarterly Review and Planning: Partners Meeting, Quarterly Review, and All Hands Meeting. 
+Every quarter we take time to review, reflect, and plan for the next quarter. There are three tasks for the Quarterly Review and Planning: Partners Meeting, Quarterly Review, and All Hands Meeting.
 
 ## Developers Session
 
-We are a remote company and as such sharing of ideas and lessons learned is impaired by the fact that we don't have the time or space to do that effectively. 
+We are a remote company and as such sharing of ideas and lessons learned is impaired by the fact that we don't have the time or space to do that effectively.
 
-In the long term, this is hurting everyone and as such `Developers Sessions` are a way to discuss ideas and questions that might have arisen during retrospective or the sprint. Followed by a short lightning talk(s), which can be impromptu or declared beforehand so others can join. 
+In the long term, this is hurting everyone and as such `Developers Sessions` are a way to discuss ideas and questions that might have arisen during retrospective or the sprint. Followed by a short lightning talk(s), which can be impromptu or declared beforehand so others can join.
 
 You can learn something from every single person in the world, no matter what their opinion on any topic is. We also believe that this is a big part of open source and our company, being able to learn and collaborate with people from all over the world who have a wide variety of different opinions on how to do things. On the other hand, a lightning talk can be a perfect way for testing how people react to a talk that you are going to have at next conference or just getting rid of that presentation fear in front of people.
 
-In order for things to not explode, the Session is limited to 30 minutes plus any lightning talks to 5min.
+In order for things to not explode, the Session is limited to 60 minutes.
 
 ### Agenda
 
 As an attendee, ask yourself:
 
-- Did I have a problem with understanding of implementation I saw during the sprint? 
+- Did I have a problem with understanding of implementation I saw during the sprint?
 - Was I annoyed by a particular workflow or something that I think is wasting my time?
 - Did I find a handy tool/method/module that I think we should use?
 - Do I have an idea about implementation we will have in the next sprint, and I want to discuss it?
 - Have I seen a great technical talk and I want to share it so we can discuss it the next time?
-- Do I want to share something I leared in a short lighning talk?
-- Do I need help with the user story I have been asigned to?
+- Do I want to share something I learned in a short lightning talk?
+- Do I need help with the user story I have been assigned to?
 
 As a curator:
 
 - Announce in #development Zoom session to join into
-- As a curator, meet and greet everyone, especially first-time joiners. 
+- As a curator, meet and greet everyone, especially first-time joiners.
 - Announce who is having the Lightning talk if one was prepared.
 - If you hear crickets, start rolling the ball with a question, an anecdote or a funny story.
 - Make sure no one is talking the whole 30 minutes, everyone should have an opinion!
@@ -87,5 +80,5 @@ When a User Story or Pull Request is getting close to being completed but there 
 
 Big cleanups (of code, documentation, or anything else) happen rarely. They are hard to organize, and to motivate for. Instead of doing big cleanups every few months (years?) when pain levels are high enough, we prefer to do constant tiny improvements with an approach called [Continual Improvement](https://en.wikipedia.org/wiki/Continual_improvement_process).
 
-For Niteo, this means that every Pull Request (except Priority Lane issues) should include at least one minor cleanup commit alongside the main PR commit. It does not need to be related to the main commit, it can be improvements for anything in the repo, however trivial. This can include code and documentation updates, typo fixes, or removal of something that no longer makes sense.
+For Niteo, this means that every Pull Request (except Priority Lane issues) should include at least one minor cleanup commit alongside the main PR commit. It does not need to be related to the main commit, it can be improvements for anything in the repository, however trivial. This can include code and documentation updates, typo fixes, or removal of something that no longer makes sense.
 


### PR DESCRIPTION
As discussed on the last alignment meeting we don't need it any more
because we are covering these topics in the retrospective meeting.

Ref: https://github.com/niteoweb/sprint/issues/56#issuecomment-485791834