### PR TITLE
Inflation adjust allowances

### DIFF
--- a/5_People/benefits.md
+++ b/5_People/benefits.md
@@ -12,16 +12,16 @@ In other words, would something boost your productivity and creativity? Good, fe
 
 ### Allowance Budget
 
-The current monthly allowance budget as of *January 2018* is:
+The current monthly allowance budget as of *January 2020* is:
 
- * Niteans: _€130 ($150)_
- * Founders: _€260_
+ * Niteans: _€130 ($155)_
+ * Founders: _€255_
 
 The monthly budgets compound every month, so whatever you do not spend this month, you can use the next month, or the one after.
 
 You can request an increase in your Allowance if you feel the current one doesn't cover all the expenses for you. You can spend a few months of future allowance balance. The maximum allowance balance you can keep is 18 months. That said, it's smart to keep at least a few months allowance, just in case something breaks.
 
-If they attended a conference in the previous year, each Nitean gets a €1000 ($1145) additional budget on the 1st of January every year.
+If they attended a conference in the previous year, each Nitean gets a €1000 ($1120) additional budget on the 1st of January every year.
 
 Every Nitean, when they transition from Trialist to a Permanent position, starts with an allowance budget that is proportional to how many months remain in the year (€1000 in January, €500 in July, etc.)
 
@@ -36,8 +36,8 @@ All conference expenses such as transport, accommodation, food, etc., are covere
 The allowance bonus accounts for all the days you are away at the conference and depends on the amount of traveling and accommodation required:
 
 * €40 ($45)/day for local conferences, in or near your home city.
-* €150 ($170)/day for international conferences.
-* €255 ($290)/day for intercontinental conferences.
+* €155 ($175)/day for international conferences.
+* €255 ($285)/day for intercontinental conferences.
 * Bonus 50%/conference day if you give a 30-60min talk at the conference or tending our booth.
 
 Conferences count as working days (7.5h per day). Transport to conferences counts too (up to 7.5h per day).


### PR DESCRIPTION
Base values:
* allowance: €125
* local conf day: €40
* international conf day: €150
* intercontinental conf day: €250

They were set in 2017. Each year we add Eurozone inflation for 2018 and 2019 and round to 5€.

* allowance: €125 * 1.67% * 1% == €128.34 -> €130
* founders allowance: €250 * 1.67% * 1% == €256.72 -> €255
* local conf day: €40 == €41.07 -> €40
* international conf day: €150 == €154.03 -> €155
* intercontinental conf day: €250 == €256.72 -> €255

Then from € values we calculate $ values, based on 1st of January exchange rate: 1.12185. Again, rounded to $5.

* yearly allowance boost: €1000 == $1121.85 -> $1120
* allowance: €130 == $145.84 -> $155
* local conf day: €40 == $44.874 -> $45
* international conf day: €155 == $175
* intercontinental conf day: €255 == $285