### PR TITLE
Moving away from daily standups

### DIFF
--- a/2_Operations/scrum.md
+++ b/2_Operations/scrum.md
@@ -19,9 +19,9 @@ Support tasks take priority over sprint for support and DevOps team.
 
 For each sprint, a new milestone is created with the name `Sprint #X` where `X` is the number of the sprint (e.g. `Sprint #4`). On Scrum sprint planning each user story that is added to the planning sprint must be also added to the new milestone. With this ZenHub will automatically generate a burndown chart and we avoid having an additional label (`Sprint #X` label).
 
-## Daily Standup
+## Standup Meetings
 
-Daily standup meetings are short meetings every day where we go over the work done on the previous day and to be done the same/next day. It is also where we discuss any blockers and where project managers can keep a tab on workload. The order for Niteans on standups is alphabetically. So the person whose first name starts with `A` goes first. Every project has its own standup time.
+Standup meetings are short meetings every other Mondays and Thursday where we go over the work done and what still needs to be done. It is also where we discuss any blockers and where project managers can keep a tab on workload. Company discussions, announcements and updates are also done on these meetings. The order for Niteans on standups is alphabetically. So the person whose first name starts with `A` goes first. Every project has its own standup time.
 
 Turn on your camera during the standup. Try to refrain from doing other things (browsing, doing support, etc.) during the meeting -- it rarely takes more than 15 minutes and we should all pay attention to everyone else for this period.
 

--- a/2_Operations/scrum.md
+++ b/2_Operations/scrum.md
@@ -21,7 +21,7 @@ For each sprint, a new milestone is created with the name `Sprint #X` where `X` 
 
 ## Standup Meetings
 
-Standup meetings are short meetings every other Mondays and Thursday where we go over the work done and what still needs to be done. It is also where we discuss any blockers and where project managers can keep a tab on workload. Company discussions, announcements and updates are also done on these meetings. The order for Niteans on standups is alphabetically. So the person whose first name starts with `A` goes first. Every project has its own standup time.
+Standup meetings are short meetings every Monday and Thursday where we go over the work done and what still needs to be done. It is also where we discuss any blockers and where project managers can keep a tab on workload. Company discussions, announcements and updates are also done on these meetings. The order for Niteans on standups is alphabetical on Nitean's first name. Every project has its own standup time.
 
 Turn on your camera during the standup. Try to refrain from doing other things (browsing, doing support, etc.) during the meeting -- it rarely takes more than 15 minutes and we should all pay attention to everyone else for this period.
 

--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -9,7 +9,7 @@
 * Every other **Tuesday and Wednesday** morning we have [Scrum meetings](https://github.com/niteoweb/handbook/blob/master/2_Operations/scrum.md):
    * Retrospective on Tuesday, Planning on Wednesday
    * 10:00 CE(S)T for the whole company in the Niteo Zoom room
-   * followed immediately by separate standups for WooCart, Easy Blog Networks and Kafkai, in their own Zoom rooms
+   * followed immediately by separate meetings for WooCart, Easy Blog Networks and Kafkai, in their own Zoom rooms
 
 Niteans are encouraged to take Fridays off for a long weekend. Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)).
 

--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -6,9 +6,11 @@
 * Every **Monday and Thursday** morning we hold a daily standup meeting:
    * 10:00 CE(S)T for the whole company in the Niteo Zoom room
    * followed immediately by separate standups for WooCart, Easy Blog Networks and Kafkai, in their own Zoom rooms
-* Every **Tuesday and Wednesday** morning we only have project standup meetings:
-   * 10:00 CE(S)T separate standups for WooCart, Easy Blog Networks and Kafkai, in their own Zoom rooms
-* No standups on **Fridays**. This way Niteans can either be more productive (focus on their Stories) or take a day off (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)). Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues.
+
+We're straying away from daily standups since there is visible increase in prodcutivity when we started implementing no standup days. Regular Zoom meetings are still happening amongst Niteans when and where needed. 
+
+Niteans are also encouraged to take Fridays off for a long weekened. Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)).
+
 * Every weekday Niteans should check their [GitHub notifications](https://github.com/notifications) so that they don't miss things that involve them.
 
 Sprint meetings replace the daily standup on these days:

--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -3,17 +3,17 @@
 
 ## Schedule
 
-* Every **Monday and Thursday** morning we hold a daily standup meeting:
+* Every **Monday and Thursday** morning we hold a standup meeting:
+   * 10:00 CE(S)T for the whole company in the Niteo Zoom room
+   * followed immediately by separate standups for WooCart, Easy Blog Networks and Kafkai, in their own Zoom rooms
+* Every other **Tuesday and Wednesday** morning we have [Scrum meetings](https://github.com/niteoweb/handbook/blob/master/2_Operations/scrum.md):
+   * Retrospective on Tuesday, Planning on Wednesday
    * 10:00 CE(S)T for the whole company in the Niteo Zoom room
    * followed immediately by separate standups for WooCart, Easy Blog Networks and Kafkai, in their own Zoom rooms
 
-We're straying away from daily standups since there is visible increase in productivity when we started implementing no-standup days. Regular Zoom meetings are still happening amongst Niteans when and where needed. 
-
-Niteans are also encouraged to take Fridays off for a long weekend. Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)).
+Niteans are encouraged to take Fridays off for a long weekend. Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)).
 
 * Every weekday Niteans should check their [GitHub notifications](https://github.com/notifications) so that they don't miss things that involve them.
-
-* We have bi-weekly Sprint Planning and Restrospective. See our [Scrum process](https://github.com/niteoweb/handbook/blob/master/2_Operations/scrum.md).
 
 Sprint meetings replace the daily standup on these days:
 

--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -7,7 +7,7 @@
    * 10:00 CE(S)T for the whole company in the Niteo Zoom room
    * followed immediately by separate standups for WooCart, Easy Blog Networks and Kafkai, in their own Zoom rooms
 
-We're straying away from daily standups since there is visible increase in prodcutivity when we started implementing no standup days. Regular Zoom meetings are still happening amongst Niteans when and where needed. 
+We're straying away from daily standups since there is visible increase in productivity when we started implementing no-standup days. Regular Zoom meetings are still happening amongst Niteans when and where needed. 
 
 Niteans are also encouraged to take Fridays off for a long weekend. Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)).
 

--- a/2_Operations/work-process.md
+++ b/2_Operations/work-process.md
@@ -9,9 +9,11 @@
 
 We're straying away from daily standups since there is visible increase in prodcutivity when we started implementing no standup days. Regular Zoom meetings are still happening amongst Niteans when and where needed. 
 
-Niteans are also encouraged to take Fridays off for a long weekened. Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)).
+Niteans are also encouraged to take Fridays off for a long weekend. Same as any other vacation off, make sure that your backup Nitean is available to handle any potential issues (see [Vacation policy](https://github.com/niteoweb/handbook/blob/master/5_People/benefits.md#vacation)).
 
 * Every weekday Niteans should check their [GitHub notifications](https://github.com/notifications) so that they don't miss things that involve them.
+
+* We have bi-weekly Sprint Planning and Restrospective. See our [Scrum process](https://github.com/niteoweb/handbook/blob/master/2_Operations/scrum.md).
 
 Sprint meetings replace the daily standup on these days:
 


### PR DESCRIPTION
We saw an increase in productivity on days where there are no standups. That said, we're doing standups on Mondays and Thursday now. Nothing changed on Retros and Planning. 

The policy is in effect starting this sprint (Sprint 82).