### PR TITLE
Inflation adjust allowances 2021

### DIFF
--- a/5_People/benefits.md
+++ b/5_People/benefits.md
@@ -17,16 +17,16 @@ In other words, would something boost your productivity, creativity, or help imp
 
 ### Allowance Budget
 
-The current monthly allowance budget as of *January 2020* is:
+The current monthly allowance budget as of *January 2021* is:
 
- * Niteans: _€130 ($155)_
+ * Niteans: _€125 ($150)_
  * Founders: _€255_
 
 The monthly budgets compound every month, so whatever you do not spend this month, you can use the next month, or the one after.
 
 You can request an increase in your Allowance if you feel the current one doesn't cover all the expenses for you. You can spend a few months of future allowance balance. The maximum allowance balance you can keep is 18 months. That said, it's smart to keep at least a few months allowance, just in case something breaks.
 
-If they attended a conference in the previous year, each Nitean gets a €1000 ($1120) additional budget on the 1st of January every year.
+If they attended a conference in the previous year, each Nitean gets a €1000 ($1220) additional budget on the 1st of January every year.
 
 Every Nitean, when they transition from Trialist to a Permanent position, starts with an allowance budget that is proportional to how many months remain in the year (€1000 in January, €500 in July, etc.)
 
@@ -40,9 +40,9 @@ All conference expenses such as transport, accommodation, food, etc., are covere
 
 The allowance bonus accounts for all the days you are away at the conference and depends on the amount of traveling and accommodation required:
 
-* €40 ($45)/day for local conferences, in or near your home city.
-* €155 ($175)/day for international conferences.
-* €255 ($285)/day for intercontinental conferences.
+* €40 ($50)/day for local conferences, in or near your home city.
+* €155 ($190)/day for international conferences.
+* €255 ($310)/day for intercontinental conferences.
 * Bonus 50%/conference day if you give a 30-60min talk at the conference or tending our booth.
 
 Conferences count as working days (7.5h per day). Transport to conferences counts too (up to 7.5h per day).
@@ -55,7 +55,7 @@ For example, John attends a 5-day IRL in Istanbul:
     * IRL venue and accommodation is covered by Niteo.
     * John spends extra €100 on snacks and a massage at the airport.
     * John gets his salary in EUR.
-    * John's monthly Allowance is 130 EUR.
+    * John's monthly Allowance is 125 EUR.
 
     The conference bonus is calculated like so (with a day of travel each way):
 
@@ -71,13 +71,13 @@ Another example: Two months later, John goes to a three-day conference in Barcel
     * Hotel and food are €600.
     * John spends extra €300 on niceties that make his trip more enjoyable.
     * John gets his salary in EUR.
-    * John's monthly Allowance is 130 EUR.
+    * John's monthly Allowance is 125 EUR.
 
     The conference bonus is calculated like so (with a day of travel each way):
 
     * €775 (5 * €155/day)
 
-    Therefore John charges the company €1900 (€500 + €500 + €600 + €300) in spent Allowance. Before the trip, John's allowance budget was €1645 (€1385 + 2x€130), so after the trip, it is now €475 (€1600 + €775 - €1900). The trip was expensive, but it sure was nice!
+    Therefore John charges the company €1900 (€500 + €500 + €600 + €300) in spent Allowance. Before the trip, John's allowance budget was €1635 (€1385 + 2x€125), so after the trip, it is now €510 (€1635 + €775 - €1900). The trip was expensive, but it sure was nice!
 
 
 ### Extending Your Trip With Vacation Days


### PR DESCRIPTION
Base values:
* allowance: €125
* local conf day: €40
* international conf day: €150
* intercontinental conf day: €250

They were set in 2017. Each year we add Eurozone inflation for 2018, 2019, 2020 and round to 5€.
We take the value for Year-on-Year value in November, from
https://tradingeconomics.com/euro-area/inflation-cpi.

* allowance: €125 + 1.67% + 1% + -0.3% == €127.09 -> €125
* founders allowance: €250 + 1.67% + 1% + -0.3% == €254.18 -> €255
* local conf day: €40 + 1.67% + 1% + -0.3% == €40.68 -> €40
* international conf day: €150 + 1.67% + 1% + -0.3% == €152.51 -> €155
* intercontinental conf day: €250 + 1.67% + 1% + -0.3% == €254.18 -> €255

Then from € values we calculate $ values, based on 1st of January exchange rate: 1.217576. Again, rounded to $5.

* yearly allowance boost: €1000 == $1217.58 -> $1220
* allowance: €125 == $152.20 -> $150
* local conf day: €40 == $48.70 -> $50
* international conf day: €155 == $188.72 -> $190
* intercontinental conf day: €255 == $310.48 -> $310

Ref: [Inflation adjust allowances (#267)](1cee741)