### PR TITLE
Add clarification to severance

### DIFF
--- a/5_People/career.md
+++ b/5_People/career.md
@@ -105,6 +105,6 @@ While many of us are good friends, we are still a business, not a family. Unlike
 * All Partners need to agree with the cancellation.
 * When cancellation is agreed, the person should be notified immediately by the immediate supervisor (usually the one doing the onboarding or has the most interaction with). From this point onwards, the person is no longer required to work, but is encouraged to take their time to hand off to other people in Niteo anything they feel is valuable. After hand-off is finished, they are free to do whatever.
 * Every Nitean (except Trialists) is entitled to a severance package paid in monthly payouts according to the following formula:
-  * up to one year full time: 1 month base salary,
-  * more than one year full time: 2 months base salary + 1 month for each additional year, capped at 6 months,
+  * up to one year permanent: 1 month base salary,
+  * more than one year permanent: 2 months base salary + 1 month for each additional year, capped at 6 months,
   * base salary is capped at 80% of level 3 salary which is the same for parental and sick leave.

--- a/5_People/career.md
+++ b/5_People/career.md
@@ -105,6 +105,6 @@ While many of us are good friends, we are still a business, not a family. Unlike
 * All Partners need to agree with the cancellation.
 * When cancellation is agreed, the person should be notified immediately by the immediate supervisor (usually the one doing the onboarding or has the most interaction with). From this point onwards, the person is no longer required to work, but is encouraged to take their time to hand off to other people in Niteo anything they feel is valuable. After hand-off is finished, they are free to do whatever.
 * Every Nitean (except Trialists) is entitled to a severance package paid in monthly payouts according to the following formula:
-  * up to one year: 1 month base salary,
-  * more than one year: 2 months base salary + 1 month for each additional year, capped at 6 months,
+  * up to one year full time: 1 month base salary,
+  * more than one year full time: 2 months base salary + 1 month for each additional year, capped at 6 months,
   * base salary is capped at 80% of level 3 salary which is the same for parental and sick leave.


### PR DESCRIPTION
We consider severance years from the permanent date on, trial months are not included.

This is how we always handled it in the past but the handbook was missing this explanation.